### PR TITLE
correct message on failed buy/sell

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,6 +1,6 @@
 import configFileTest from '../config/config-test.json';
 // Use this on production
-//import configFileProduction from '../config/files/config.json';
+// import configFileProduction from '../config/files/config.json';
 // Using this due to CI error
 import configFileProduction from '../config/config.json';
 


### PR DESCRIPTION
Fix message to display correct token name when user doesn't have sufficient balance.