### PR TITLE
Feature/add support trading competition

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ This is a detailed list of planned features to add to this DEX (includes VeriDex
 -   [x] Support for mobile dapp browswers like Enjin and Coinbase
 -   [x] Mobile friendly
 -   [x] Connect to 0x mesh
+-   [x] Adding Account market stats
 -   [ ] Click on buy and sell button to auto-fill
 -   [ ] Create a costumized front page
 -   [ ] Order Matching on the Frontend when doing limit orders
@@ -83,6 +84,8 @@ This is a detailed list of planned features to add to this DEX (includes VeriDex
 -   [ ] [WalletConnect](https://docs.walletconnect.org/)
 -   [x] [EnjinWallet](https://enjin.io/products/wallet)
 -   [x] [CoinbaseWallet](https://wallet.coinbase.com/)
+-   [x] [TrustWallet](https://trustwallet.com)
+-   [x] [CipherBrowser](https://www.cipherbrowser.com/)
 
 ### Using VeriDex relayer
 

--- a/firebase.json
+++ b/firebase.json
@@ -1,6 +1,7 @@
 {
     "hosting": {
         "public": "build",
-        "ignore": ["firebase.json", "**/.*", "**/node_modules/**"]
+        "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+        "headers": [{ "source": "/service-worker.js", "headers": [{ "key": "Cache-Control", "value": "no-cache" }] }]
     }
 }

--- a/src/components/erc20/erc20_app.tsx
+++ b/src/components/erc20/erc20_app.tsx
@@ -9,6 +9,7 @@ import { getThemeByMarketplace } from '../../themes/theme_meta_data_utils';
 import { MARKETPLACES } from '../../util/types';
 
 import { ToolbarContentContainer } from './common/toolbar_content';
+import { AccountTradingsPage } from './pages/account_trading';
 import { Marketplace } from './pages/marketplace';
 import { MyWallet } from './pages/my_wallet';
 import { TokensListPage } from './pages/tokens_list';
@@ -25,6 +26,11 @@ export const Erc20App = () => {
                     <Route exact={true} path={`${ERC20_APP_BASE_PATH}/`} component={Marketplace} />
                     <Route exact={true} path={`${ERC20_APP_BASE_PATH}/my-wallet`} component={MyWallet} />
                     <Route exact={true} path={`${ERC20_APP_BASE_PATH}/listed-tokens`} component={TokensListPage} />
+                    <Route
+                        exact={true}
+                        path={`${ERC20_APP_BASE_PATH}/trading-competition`}
+                        component={AccountTradingsPage}
+                    />
                 </Switch>
             </GeneralLayoutContainer>
         </ThemeProvider>

--- a/src/components/erc20/marketplace/account_tradings.tsx
+++ b/src/components/erc20/marketplace/account_tradings.tsx
@@ -135,8 +135,8 @@ const AccountTradings: React.FC<Props> = props => {
 
     return (
         <AccountTradingsCard
-            title={`Trading Stats ${marketName} -  From:${new Date(from).toDateString()}   To: ${new Date(
-                to,
+            title={`Trading Stats ${marketName} -  From:${new Date(Number(from)).toDateString()}   To: ${new Date(
+                Number(to),
             ).toDateString()}`}
         >
             {content}

--- a/src/components/erc20/marketplace/account_tradings.tsx
+++ b/src/components/erc20/marketplace/account_tradings.tsx
@@ -1,0 +1,167 @@
+import React, { useEffect, useState } from 'react';
+import { connect } from 'react-redux';
+import styled from 'styled-components';
+
+import { changeMarket, fetchAccountMarketStats as fetchStats, goToHome } from '../../../store/actions';
+import { getAccountMarketStats, getBaseToken, getQuoteToken } from '../../../store/selectors';
+import {
+    getCurrencyPairByMarket,
+    getCurrencyPairFromTokens,
+    getTokensFromCurrencyPair,
+} from '../../../util/known_currency_pairs';
+import { marketToString } from '../../../util/markets';
+import { getAddressLinkExplorer } from '../../../util/transaction_link';
+import { AccountMarketStat, CurrencyPair, StoreState, Token } from '../../../util/types';
+import { Card } from '../../common/card';
+import { EmptyContent } from '../../common/empty_content';
+import { LoadingWrapper } from '../../common/loading';
+import { CustomTD, Table, TH, THead, TR } from '../../common/table';
+
+const AccountTradingsCard = styled(Card)`
+    height: 100%;
+    overflow: auto;
+`;
+
+interface StateProps {
+    baseToken: Token | null;
+    quoteToken: Token | null;
+    accountMarketStats: AccountMarketStat[] | undefined;
+}
+
+interface DispatchProps {
+    changeMarket: (currencyPair: CurrencyPair) => any;
+    goToHome: () => any;
+    fetchAccountMarketStats: (market: string | null, from: number, to: number) => any;
+}
+
+type Props = StateProps & DispatchProps;
+
+const AccountEtherscanLink = styled.a`
+    align-items: center;
+    color: ${props => props.theme.componentsTheme.myWalletLinkColor};
+    display: flex;
+    font-size: 16px;
+    font-weight: 500;
+    text-decoration: none;
+
+    &:hover {
+        text-decoration: underline;
+    }
+`;
+
+export const ClicableTD = styled(CustomTD)`
+    cursor: pointer;
+`;
+
+const statsToRow = (stat: AccountMarketStat, index: number) => {
+    return (
+        <TR key={index}>
+            <ClicableTD styles={{ textAlign: 'center', tabular: true }}>
+                <AccountEtherscanLink href={getAddressLinkExplorer(stat.address)} target={'_blank'}>
+                    {`${stat.address}`}
+                </AccountEtherscanLink>
+            </ClicableTD>
+            <CustomTD styles={{ textAlign: 'center', tabular: true }}>{stat.totalClosedOrders}</CustomTD>
+            <CustomTD styles={{ textAlign: 'center', tabular: true }}>{stat.totalAmountBase}</CustomTD>
+            <CustomTD styles={{ textAlign: 'center', tabular: true }}>{stat.totalAmountQuote}</CustomTD>
+        </TR>
+    );
+};
+
+const parsedUrl = new URL(window.location.href.replace('#/', ''));
+const fromQuery = parsedUrl.searchParams.get('from');
+const toQuery = parsedUrl.searchParams.get('to');
+const marketQuery = parsedUrl.searchParams.get('market');
+
+const AccountTradings: React.FC<Props> = props => {
+    const { accountMarketStats, baseToken, quoteToken, fetchAccountMarketStats } = props;
+    let content: React.ReactNode;
+    const [isLoading, setLoading] = useState(true);
+    let currencyPair: CurrencyPair | null = null;
+    let isInvalidMarket = false;
+    try {
+        if (marketQuery) {
+            currencyPair = getCurrencyPairByMarket(marketQuery);
+        } else {
+            if (baseToken && quoteToken) {
+                currencyPair = getCurrencyPairFromTokens(baseToken, quoteToken);
+            }
+        }
+    } catch (e) {
+        isInvalidMarket = true;
+    }
+
+    const month = new Date().getUTCMonth() + 1;
+    const year = new Date().getUTCFullYear();
+    const monthDays = new Date(year, month, 0).getDate();
+    const from = fromQuery || new Date(`${month}-1-${year}`).getTime();
+    const to = toQuery || new Date(`${month}-${monthDays}-${year}`).getTime();
+    useEffect(() => {
+        if (baseToken && quoteToken && !isInvalidMarket && currencyPair) {
+            const market = marketToString(currencyPair);
+            fetchAccountMarketStats(market, Number(from), Number(to));
+            setLoading(false);
+        }
+        if (isInvalidMarket) {
+            setLoading(false);
+        }
+    }, [baseToken, quoteToken]);
+
+    if (accountMarketStats && !isInvalidMarket && currencyPair) {
+        const [bToken, qToken] = getTokensFromCurrencyPair(currencyPair);
+        content = (
+            <Table isResponsive={true}>
+                <THead>
+                    <TR>
+                        <TH styles={{ textAlign: 'center' }}>Account</TH>
+                        <TH styles={{ textAlign: 'center' }}>Orders Closed</TH>
+                        <TH styles={{ textAlign: 'center' }}>Base Amount ({bToken.symbol})</TH>
+                        <TH styles={{ textAlign: 'center' }}>Quote Amount ({qToken.symbol})</TH>
+                    </TR>
+                </THead>
+                <tbody>{accountMarketStats.map((a, index: number) => statsToRow(a, index))}</tbody>
+            </Table>
+        );
+    } else {
+        if (isLoading) {
+            content = <LoadingWrapper minHeight="120px" />;
+        } else if (isInvalidMarket) {
+            content = <EmptyContent alignAbsoluteCenter={true} text="Market not available" />;
+        } else {
+            content = <EmptyContent alignAbsoluteCenter={true} text="There are no stats to show" />;
+        }
+    }
+    const marketName = currencyPair ? marketToString(currencyPair) : '';
+
+    return (
+        <AccountTradingsCard
+            title={`Trading Stats ${marketName} -  From:${new Date(from).toDateString()}   To: ${new Date(
+                to,
+            ).toDateString()}`}
+        >
+            {content}
+        </AccountTradingsCard>
+    );
+};
+
+const mapStateToProps = (state: StoreState): StateProps => {
+    return {
+        baseToken: getBaseToken(state),
+        quoteToken: getQuoteToken(state),
+        accountMarketStats: getAccountMarketStats(state),
+    };
+};
+const mapDispatchToProps = (dispatch: any): DispatchProps => {
+    return {
+        changeMarket: (currencyPair: CurrencyPair) => dispatch(changeMarket(currencyPair)),
+        fetchAccountMarketStats: (market, from, to) => dispatch(fetchStats(market, from, to)),
+        goToHome: () => dispatch(goToHome()),
+    };
+};
+
+const AccountTradingsContainer = connect(
+    mapStateToProps,
+    mapDispatchToProps,
+)(AccountTradings);
+
+export { AccountTradings, AccountTradingsContainer };

--- a/src/components/erc20/marketplace/order_book.tsx
+++ b/src/components/erc20/marketplace/order_book.tsx
@@ -63,7 +63,7 @@ const OrderbookCard = styled(Card)`
     display: flex;
     flex-direction: column;
     flex-grow: 1;
-    max-height: 100%;
+    max-height: 700px;
 
     > div:first-child {
         flex-grow: 0;

--- a/src/components/erc20/marketplace/order_fills.tsx
+++ b/src/components/erc20/marketplace/order_fills.tsx
@@ -49,9 +49,12 @@ const fillToRow = (fill: Fill, index: number, _setMarket: any) => {
     const tokenQuoteSymbol = isWeth(fill.tokenQuote.symbol) ? 'ETH' : fill.tokenQuote.symbol.toUpperCase();
     const displayAmountQuote = `${amountQuote} ${tokenQuoteSymbol}`;
     const market = `${fill.tokenBase.symbol.toUpperCase()}/${tokenQuoteSymbol}`;
-
-    const currencyPair: CurrencyPair = getCurrencyPairByTokensSymbol(fill.tokenBase.symbol, fill.tokenQuote.symbol);
-
+    let currencyPair: CurrencyPair;
+    try {
+        currencyPair = getCurrencyPairByTokensSymbol(fill.tokenBase.symbol, fill.tokenQuote.symbol);
+    } catch {
+        return '';
+    }
     const price = parseFloat(fill.price.toString()).toFixed(currencyPair.config.pricePrecision);
 
     const setMarket = () => _setMarket(currencyPair);

--- a/src/components/erc20/marketplace/order_history.tsx
+++ b/src/components/erc20/marketplace/order_history.tsx
@@ -3,9 +3,9 @@ import React from 'react';
 import { connect } from 'react-redux';
 import styled from 'styled-components';
 
-import { UI_DECIMALS_DISPLAYED_PRICE_ETH } from '../../../common/constants';
 import { getBaseToken, getQuoteToken, getUserOrders, getWeb3State } from '../../../store/selectors';
 import { themeBreakPoints } from '../../../themes/commons';
+import { getCurrencyPairFromTokens } from '../../../util/known_currency_pairs';
 import { tokenAmountInUnits } from '../../../util/tokens';
 import { OrderSide, StoreState, Token, UIOrder, Web3State } from '../../../util/types';
 import { Card } from '../../common/card';
@@ -37,7 +37,7 @@ const SideTD = styled(CustomTD)<{ side: OrderSide }>`
         props.side === OrderSide.Buy ? props.theme.componentsTheme.green : props.theme.componentsTheme.red};
 `;
 
-const orderToRow = (order: UIOrder, index: number, baseToken: Token) => {
+const orderToRow = (order: UIOrder, index: number, baseToken: Token, quoteToken: Token) => {
     const sideLabel = order.side === OrderSide.Sell ? 'Sell' : 'Buy';
     const size = tokenAmountInUnits(order.size, baseToken.decimals, baseToken.displayDecimals);
     let status = '--';
@@ -50,8 +50,8 @@ const orderToRow = (order: UIOrder, index: number, baseToken: Token) => {
         isOrderFillable = order.status === OrderStatus.Fillable;
         status = isOrderFillable ? 'Open' : 'Filled';
     }
-
-    const price = parseFloat(order.price.toString()).toFixed(UI_DECIMALS_DISPLAYED_PRICE_ETH);
+    const currencyPair = getCurrencyPairFromTokens(baseToken, quoteToken);
+    const price = parseFloat(order.price.toString()).toFixed(currencyPair.config.pricePrecision);
 
     return (
         <TR key={index}>
@@ -101,7 +101,9 @@ class OrderHistory extends React.Component<Props> {
                                     <TH>&nbsp;</TH>
                                 </TR>
                             </THead>
-                            <tbody>{ordersToShow.map((order, index) => orderToRow(order, index, baseToken))}</tbody>
+                            <tbody>
+                                {ordersToShow.map((order, index) => orderToRow(order, index, baseToken, quoteToken))}
+                            </tbody>
                         </Table>
                     );
                 }

--- a/src/components/erc20/pages/account_trading.tsx
+++ b/src/components/erc20/pages/account_trading.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { FiatOnRampModalContainer } from '../../account/fiat_modal';
+import { ColumnWide } from '../../common/column_wide';
+import { Content } from '../common/content_wrapper';
+import { AccountTradingsContainer } from '../marketplace/account_tradings';
+
+const ColumnWideMyWallet = styled(ColumnWide)`
+    margin-left: 0;
+
+    &:last-child {
+        margin-left: 0;
+    }
+`;
+
+export const AccountTradingsPage = () => (
+    <Content>
+        <ColumnWideMyWallet>
+            <AccountTradingsContainer />
+        </ColumnWideMyWallet>
+        <FiatOnRampModalContainer />
+    </Content>
+);

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,9 +1,9 @@
 // Use this on production
-// import configFileProduction from '../config/files/config.json';
+import configFileProduction from '../config/files/config.json';
 
 // Using this due to CI error
 import configFileTest from './config-test.json';
-import configFileProduction from './config.json';
+// import configFileProduction from './config.json';
 
 let configFile: any;
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -49,4 +49,4 @@ ReactDOM.render(Web3WrappedApp, document.getElementById('root'));
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.
 // Learn more about service workers: http://bit.ly/CRA-PWA
-serviceWorker.unregister();
+serviceWorker.register();

--- a/src/services/relayer.ts
+++ b/src/services/relayer.ts
@@ -4,7 +4,7 @@ import { RateLimit } from 'async-sema';
 
 import { RELAYER_URL } from '../common/constants';
 import { tokenAmountInUnitsToBigNumber } from '../util/tokens';
-import { MarketData, Token } from '../util/types';
+import { AccountMarketStat, MarketData, Token } from '../util/types';
 
 export class Relayer {
     private readonly _client: HttpClient;
@@ -60,6 +60,7 @@ export class Relayer {
 
         return null;
     }
+
     public async getCurrencyPairMarketDataAsync(baseToken: Token, quoteToken: Token): Promise<MarketData> {
         await this._rateLimit();
         const { asks, bids } = await this._client.getOrderbookAsync({
@@ -158,4 +159,25 @@ export const getRelayer = (): Relayer => {
     }
 
     return relayer;
+};
+
+export const getAccountMarketStatsFromRelayer = async (
+    pair: string,
+    from: number,
+    to: number,
+): Promise<AccountMarketStat[]> => {
+    const headers = new Headers({
+        'content-type': 'application/json',
+    });
+
+    const init: RequestInit = {
+        method: 'GET',
+        headers,
+    };
+    const response = await fetch(`${RELAYER_URL}/markets/${pair}/accounts/stats?from=${from}&to=${to}`, init);
+    if (response.ok) {
+        return (await response.json()) as AccountMarketStat[];
+    } else {
+        return [];
+    }
 };

--- a/src/store/relayer/actions.ts
+++ b/src/store/relayer/actions.ts
@@ -11,7 +11,7 @@ import {
     getAllOrdersAsUIOrdersWithoutOrdersInfo,
     getUserOrdersAsUIOrders,
 } from '../../services/orders';
-import { getRelayer } from '../../services/relayer';
+import { getAccountMarketStatsFromRelayer, getRelayer } from '../../services/relayer';
 import { isWeth } from '../../util/known_tokens';
 import { getLogger } from '../../util/logger';
 import {
@@ -21,7 +21,16 @@ import {
     sumTakerAssetFillableOrders,
 } from '../../util/orders';
 import { getTransactionOptions } from '../../util/transactions';
-import { NotificationKind, OrderSide, RelayerState, ThunkCreator, Token, UIOrder, Web3State } from '../../util/types';
+import {
+    AccountMarketStat,
+    NotificationKind,
+    OrderSide,
+    RelayerState,
+    ThunkCreator,
+    Token,
+    UIOrder,
+    Web3State,
+} from '../../util/types';
 import { updateTokenBalances } from '../blockchain/actions';
 import { getAllCollectibles } from '../collectibles/actions';
 import {
@@ -50,6 +59,10 @@ export const setUserOrders = createAction('relayer/USER_ORDERS_set', resolve => 
     return (orders: UIOrder[]) => resolve(orders);
 });
 
+export const setAccountMarketStats = createAction('relayer/ACCOUNT_MARKET_STATS_set', resolve => {
+    return (accountMarketStats: AccountMarketStat[]) => resolve(accountMarketStats);
+});
+
 export const getAllOrders: ThunkCreator = () => {
     return async (dispatch, getState) => {
         const state = getState();
@@ -74,6 +87,17 @@ export const getAllOrders: ThunkCreator = () => {
             dispatch(setOrders(uiOrders));
         } catch (err) {
             logger.error(`getAllOrders: fetch orders from the relayer failed.`, err);
+        }
+    };
+};
+
+export const fetchAccountMarketStats: ThunkCreator = (market, from, to) => {
+    return async (dispatch, _getState) => {
+        try {
+            const accountMarketStats: AccountMarketStat[] = await getAccountMarketStatsFromRelayer(market, from, to);
+            dispatch(setAccountMarketStats(accountMarketStats));
+        } catch (err) {
+            logger.error(`get Market Account Stats: fetch account stats from the relayer failed.`, err);
         }
     };
 };

--- a/src/store/relayer/reducers.ts
+++ b/src/store/relayer/reducers.ts
@@ -7,16 +7,19 @@ import { RootAction } from '../reducers';
 const initialRelayerState: RelayerState = {
     orders: [],
     userOrders: [],
+    accountMarketStats: [],
 };
 
 export function relayer(state: RelayerState = initialRelayerState, action: RootAction): RelayerState {
     switch (action.type) {
         case getType(actions.setOrders):
             return { ...state, orders: action.payload };
+        case getType(actions.setAccountMarketStats):
+            return { ...state, accountMarketStats: action.payload };
         case getType(actions.setUserOrders):
             return { ...state, userOrders: action.payload };
         case getType(actions.initializeRelayerData):
-            return action.payload;
+            return { ...state, ...action.payload };
         default:
             return state;
     }

--- a/src/store/selectors.ts
+++ b/src/store/selectors.ts
@@ -66,6 +66,7 @@ export const getCollectibleById = (state: StoreState, props: { collectibleId: st
 export const getSelectedCollectible = (state: StoreState) => state.collectibles.collectibleSelected;
 export const getCurrentRoutePath = (state: StoreState) => state.router.location.pathname;
 export const getRouterLocationSearch = (state: StoreState) => state.router.location.search;
+export const getAccountMarketStats = (state: StoreState) => state.relayer.accountMarketStats;
 
 export const getCurrentMarketPlace = createSelector(
     getCurrentRoutePath,
@@ -156,6 +157,8 @@ export const getOpenOrders = createSelector(
         switch (web3State) {
             case Web3State.NotInstalled:
             case Web3State.Error:
+            case Web3State.Connect:
+            case Web3State.Connecting:
             case Web3State.Locked: {
                 return orders;
             }

--- a/src/util/known_currency_pairs.ts
+++ b/src/util/known_currency_pairs.ts
@@ -1,8 +1,35 @@
 import { availableMarkets } from '../common/markets';
 
-import { CurrencyPair } from './types';
+import { getKnownTokens } from './known_tokens';
+import { CurrencyPair, Token } from './types';
 
 export const getCurrencyPairByTokensSymbol = (base: string, quote: string): CurrencyPair => {
+    const currencyPair = availableMarkets.find(m => m.base === base.toLowerCase() && m.quote === quote.toLowerCase());
+    if (!currencyPair) {
+        throw new Error(`Currency pair with base token ${base} and quote token ${quote} not found in known markets`);
+    }
+    return currencyPair;
+};
+
+export const getCurrencyPairFromTokens = (base: Token, quote: Token): CurrencyPair => {
+    const currencyPair = availableMarkets.find(
+        m => m.base === base.symbol.toLowerCase() && m.quote === quote.symbol.toLowerCase(),
+    );
+    if (!currencyPair) {
+        throw new Error(`Currency pair with base token ${base} and quote token ${quote} not found in known markets`);
+    }
+    return currencyPair;
+};
+
+export const getTokensFromCurrencyPair = (currencyPair: CurrencyPair): Token[] => {
+    const knownToken = getKnownTokens();
+    const baseToken = knownToken.getTokenBySymbol(currencyPair.base);
+    const quoteToken = knownToken.getTokenBySymbol(currencyPair.quote);
+    return [baseToken, quoteToken];
+};
+
+export const getCurrencyPairByMarket = (market: string): CurrencyPair => {
+    const [base, quote] = market.split('-');
     const currencyPair = availableMarkets.find(m => m.base === base.toLowerCase() && m.quote === quote.toLowerCase());
     if (!currencyPair) {
         throw new Error(`Currency pair with base token ${base} and quote token ${quote} not found in known markets`);

--- a/src/util/provider_factory.ts
+++ b/src/util/provider_factory.ts
@@ -1,0 +1,30 @@
+import { ZeroExProvider } from '0x.js';
+// tslint:disable-next-line: no-implicit-dependencies
+import { providerUtils } from '@0x/utils';
+
+import { Maybe } from './types';
+
+export const providerFactory = {
+    getInjectedProviderIfExists: (): Maybe<ZeroExProvider> => {
+        const injectedProviderIfExists = (window as any).ethereum;
+        if (injectedProviderIfExists !== undefined) {
+            const provider = providerUtils.standardizeOrThrow(injectedProviderIfExists);
+            return provider;
+        }
+        const injectedWeb3IfExists = (window as any).web3;
+        if (injectedWeb3IfExists !== undefined && injectedWeb3IfExists.currentProvider !== undefined) {
+            const currentProvider = injectedWeb3IfExists.currentProvider;
+            const provider = providerUtils.standardizeOrThrow(currentProvider);
+            return provider;
+        }
+
+        const injectedEnjinProviderIfExists = (window as any).enjin;
+        if (injectedEnjinProviderIfExists !== undefined) {
+            const currentProvider = injectedEnjinProviderIfExists;
+            const provider = providerUtils.standardizeOrThrow(currentProvider);
+            return provider;
+        }
+
+        return undefined;
+    },
+};

--- a/src/util/transaction_link.ts
+++ b/src/util/transaction_link.ts
@@ -22,5 +22,9 @@ export const getTransactionLink = (hash: string): string => {
 };
 
 export const viewAddressOnEtherscan = (ethAccount: string) => {
-    window.open(`${ETHERSCAN_URL[NETWORK_ID]}/address/${ethAccount}`);
+    window.open(`${ETHERSCAN_URL[NETWORK_ID]}address/${ethAccount}`);
+};
+
+export const getAddressLinkExplorer = (ethAccount: string): string => {
+    return `${ETHERSCAN_URL[NETWORK_ID]}address/${ethAccount}`;
 };

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -14,6 +14,8 @@ export interface TabItem {
     text: string;
 }
 
+export type Maybe<T> = T | undefined;
+
 export enum Network {
     Mainnet = 1,
     Ropsten = 3,
@@ -84,6 +86,7 @@ export interface BlockchainState {
 export interface RelayerState {
     readonly orders: UIOrder[];
     readonly userOrders: UIOrder[];
+    readonly accountMarketStats?: AccountMarketStat[];
 }
 
 export interface UIState {
@@ -391,6 +394,8 @@ export enum Wallet {
     WalletConnect = 'WalletConnect',
     Coinbase = 'Coinbase Wallet',
     Enjin = 'Enjin Wallet',
+    Cipher = 'Cipher Wallet',
+    Trust = 'Trust Wallet',
 }
 
 export interface Collectible {
@@ -516,5 +521,16 @@ export enum ProviderType {
     TrustWallet = 'TRUST_WALLET',
     Opera = 'OPERA',
     Fallback = 'FALLBACK',
+    // tslint:disable-next-line: max-file-line-count
+}
+
+export interface AccountMarketStat {
+    pair: string;
+    address: string;
+    totalAmountQuote: string;
+    totalAmountBase: string;
+    totalMakerFeePaid?: string;
+    totalTakerFeePaid?: string;
+    totalClosedOrders: number;
     // tslint:disable-next-line: max-file-line-count
 }


### PR DESCRIPTION
feature - Add support to created and display trading competitions on Veridex. It accepts non required parameters from, to, market where from and to is the Unix timestamp in milliseconds and market is know market to Veridex.

Add support for Trust Wallet and Cipher mobile browser

fix on order history price