### PR TITLE
Feature/add instant page for tipgram tokens

### DIFF
--- a/.github/funding.yml
+++ b/.github/funding.yml
@@ -1,0 +1,1 @@
+patreon: veridex

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -1,7 +1,7 @@
 import { Validator } from 'jsonschema';
 
 import { configFile, configFileIEO, configTipBot, configTipBotWhitelistAddresses } from '../config';
-import { ConfigFile, ConfigFileIEO, ConfigFileTipBot, AssetBot } from '../util/types';
+import { AssetBot, ConfigFile, ConfigFileIEO, ConfigFileTipBot } from '../util/types';
 
 import { configIEOSchema, configSchema, schemas } from './configSchema';
 
@@ -49,7 +49,6 @@ export class ConfigIEO {
         return this.getInstance()._configBot;
     }
 
-
     constructor() {
         this._validator = new Validator();
         for (const schema of schemas) {
@@ -58,22 +57,21 @@ export class ConfigIEO {
         this._validator.validate(configFileIEO, configIEOSchema, { throwError: true });
         this._config = configFileIEO;
 
-        const tokens: AssetBot[] = []
+        const tokens: AssetBot[] = [];
         for (const [key, value] of Object.entries(configTipBot.tokens)) {
             const asset = value as Partial<AssetBot>;
-            const tokenConfigs = (<any>configTipBotWhitelistAddresses.tokens)[key]
-            if(tokenConfigs){
+            const tokenConfigs = (configTipBotWhitelistAddresses.tokens as any)[key];
+            if (tokenConfigs) {
                 asset.whitelistAddresses = tokenConfigs.whitelistAddresses;
-                asset.feePercentage = tokenConfigs.feePercentage;
-            }else{
+                asset.feePercentage = String(tokenConfigs.feePercentage);
+            } else {
                 asset.whitelistAddresses = configTipBotWhitelistAddresses.defaultWhitelistAddresses;
-                asset.feePercentage = configTipBotWhitelistAddresses.defaultFeePercentage;
+                asset.feePercentage = String(configTipBotWhitelistAddresses.defaultFeePercentage);
             }
 
-
-            tokens.push(asset as AssetBot);     
+            tokens.push(asset as AssetBot);
         }
 
-        this._configBot = {tokens: tokens};
+        this._configBot = { tokens };
     }
 }

--- a/src/components/erc20/account/mobile_wallet_connection_content.tsx
+++ b/src/components/erc20/account/mobile_wallet_connection_content.tsx
@@ -7,7 +7,6 @@ import styled from 'styled-components';
 import {
     goToHome,
     goToHomeLaunchpad,
-    goToHomeMarginLend,
     goToWallet,
     logoutWallet,
     openFiatOnRampModal,
@@ -63,10 +62,10 @@ export const MobileWalletConnectionContent = () => {
         dispatch(openSideBar(false));
     };
 
-    const onGoToMarginLend = () => {
+    /*const onGoToMarginLend = () => {
         dispatch(goToHomeMarginLend());
         dispatch(openSideBar(false));
-    };
+    };*/
 
     const onGoToWallet = () => {
         dispatch(goToWallet());
@@ -101,7 +100,7 @@ export const MobileWalletConnectionContent = () => {
                 <ListItem onClick={onGoToHome}>Home</ListItem>
                 <ListItem onClick={onGoToWallet}>Wallet</ListItem>
                 <ListItem onClick={onGoToLaunchpad}>Launchpad</ListItem>
-                <ListItem onClick={onGoToMarginLend}>Lend</ListItem>
+                {/*<ListItem onClick={onGoToMarginLend}>Lend</ListItem>*/}
                 <hr />
                 <CopyToClipboard text={ethAccount ? ethAccount : ''}>
                     <ListItemFlex>

--- a/src/components/erc20/account/wallet_connection_content.tsx
+++ b/src/components/erc20/account/wallet_connection_content.tsx
@@ -53,7 +53,7 @@ class WalletConnectionContent extends React.PureComponent<Props> {
                 <DropdownTextItem onClick={connectToExplorer} text="Track DEX volume" />
                 <DropdownTextItem onClick={openFabrx} text="Set Alerts" />
                 <DropdownTextItem onClick={onGoToHomeLaunchpad} text="Launchpad" />
-                <DropdownTextItem onClick={onGoToHomeMarginLend} text="Lend" />
+                {/*<DropdownTextItem onClick={onGoToHomeMarginLend} text="Lend" />*/}
                 <DropdownTextItem onClick={onLogoutWallet} text="Logout Wallet" />
             </DropdownItems>
         );

--- a/src/components/erc20/common/0xinstant.tsx
+++ b/src/components/erc20/common/0xinstant.tsx
@@ -5,6 +5,7 @@ import { useLocation } from 'react-router-dom';
 import { FEE_RECIPIENT, INSTANT_FEE_PERCENTAGE, RELAYER_URL } from '../../../common/constants';
 import { getUserIEOSignedOrders } from '../../../services/relayer';
 import { getKnownTokens } from '../../../util/known_tokens';
+import { getKnownTokensIEO } from '../../../util/known_tokens_ieo';
 import { Token, TokenIEO, Wallet } from '../../../util/types';
 import { PageLoading } from '../../common/page_loading';
 
@@ -73,18 +74,27 @@ export const ZeroXInstantComponent = (props: Props) => {
         const tokenName = query.get('token');
         const tokenSymbol = query.get('symbol');
         const isEIO = query.get('isEIO');
+        const isBot = query.get('isBot');
         // TODO refactor this to be better
         try {
             const knownTokens = getKnownTokens();
+            const knownTokensIEO = getKnownTokensIEO();
             if (tokenName) {
-                token = knownTokens.getTokenByName(tokenName);
+                isBot
+                    ? (token = knownTokensIEO.getTokenBotByName(tokenName))
+                    : (token = knownTokens.getTokenByName(tokenName));
             }
             if (tokenSymbol) {
-                token = knownTokens.getTokenBySymbol(tokenSymbol);
+                isBot
+                    ? (token = knownTokensIEO.getTokenBotBySymbol(tokenSymbol))
+                    : (token = knownTokens.getTokenBySymbol(tokenSymbol));
             }
             if (token) {
                 const isTokenIEO = knownTokens.isIEOKnownAddress(token.address);
                 if (isTokenIEO) {
+                    orderSource = undefined;
+                }
+                if (isBot) {
                     orderSource = undefined;
                 }
             }
@@ -92,7 +102,30 @@ export const ZeroXInstantComponent = (props: Props) => {
             if (isEIO && token) {
                 const baseToken = token as TokenIEO;
                 const wethToken = knownTokens.getWethToken();
+
                 orderSource = await getUserIEOSignedOrders(baseToken.owners[0].toLowerCase(), baseToken, wethToken);
+
+                if (!orderSource || orderSource.length === 0) {
+                    orderSource = undefined;
+                }
+                feePercentage = Number(baseToken.feePercentage);
+            } else if (isBot && token) {
+                const baseToken = token as TokenIEO;
+                const wethToken = knownTokens.getWethToken();
+                const owners = baseToken.owners;
+
+                // iterate to found orders by whitelist address order
+                // TODO: create endpoint to retrieve orders ordered by address
+                for (const owner of owners) {
+                    orderSource = (await getUserIEOSignedOrders(
+                        owner.toLowerCase(),
+                        baseToken,
+                        wethToken,
+                    )) as SignedOrder[];
+                    if (orderSource && orderSource.length > 0) {
+                        break;
+                    }
+                }
                 if (!orderSource || orderSource.length === 0) {
                     orderSource = undefined;
                 }
@@ -133,7 +166,7 @@ export const ZeroXInstantComponent = (props: Props) => {
                 'body',
             );
         } else {
-            setText('ERROR! Please Reload the page');
+            setText('ERROR! No orders for this Asset. Please Reload the page');
             setError(true);
         }
     };

--- a/src/components/erc20/ieo_desk/ieo_order.tsx
+++ b/src/components/erc20/ieo_desk/ieo_order.tsx
@@ -202,6 +202,8 @@ const BigInputNumberTokenLabel = (props: { tokenSymbol: string }) => (
 
 const parsedUrl = new URL(window.location.href.replace('#/', ''));
 const tokenName = parsedUrl.searchParams.get('token');
+const symbol = parsedUrl.searchParams.get('symbol');
+const bot = parsedUrl.searchParams.get('bot');
 
 class IEOOrder extends React.Component<Props, State> {
     public state: State = {
@@ -217,10 +219,19 @@ class IEOOrder extends React.Component<Props, State> {
 
     public componentDidMount = async () => {
         const known_tokens = getKnownTokensIEO();
+        let token;
         if (tokenName) {
-            const token = known_tokens.getTokenByName(tokenName);
+            bot
+                ? (token = known_tokens.getTokenBotByName(tokenName))
+                : (token = known_tokens.getTokenByName(tokenName));
             await this.props.onFetchBaseTokenIEO(token);
-        } else {
+        }
+        if (symbol) {
+            bot ? (token = known_tokens.getTokenBotBySymbol(symbol)) : (token = known_tokens.getTokenBySymbol(symbol));
+            await this.props.onFetchBaseTokenIEO(token);
+        }
+
+        if (!token) {
             const tokens = known_tokens.getTokens();
             await this.props.onFetchBaseTokenIEO(tokens[0]);
         }
@@ -235,10 +246,21 @@ class IEOOrder extends React.Component<Props, State> {
         }
         if (newProps.ethAccount !== prevProps.ethAccount) {
             const known_tokens = getKnownTokensIEO();
+            let token;
             if (tokenName) {
-                const token = known_tokens.getTokenByName(tokenName);
+                bot
+                    ? (token = known_tokens.getTokenBotByName(tokenName))
+                    : (token = known_tokens.getTokenByName(tokenName));
                 await this.props.onFetchBaseTokenIEO(token);
-            } else {
+            }
+            if (symbol) {
+                bot
+                    ? (token = known_tokens.getTokenBotBySymbol(symbol))
+                    : (token = known_tokens.getTokenBySymbol(symbol));
+                await this.props.onFetchBaseTokenIEO(token);
+            }
+
+            if (!token) {
                 const tokens = known_tokens.getTokens();
                 await this.props.onFetchBaseTokenIEO(tokens[0]);
             }

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -6,10 +6,14 @@ import configFileProduction from '../config/files/config.json';
 // import configFileIEOProduction from './config-ieo.json';
 import configFileTest from './config-test.json';
 import configFileIEOProduction from './files/config-ieo.json';
+import configTipBot from './files/settingsAssets.json'
+import configTipBotWhitelistAddresses from './files/settingsAssetsWhitelistAddresses.json'
 // import configFileProduction from './config.json';
 
 let configFile: any;
 let configFileIEO: any;
+
+
 
 if (process.env.NODE_ENV === 'test') {
     configFile = configFileTest;
@@ -23,4 +27,4 @@ if (process.env.NODE_ENV === 'development') {
 
 configFileIEO = configFileIEOProduction;
 
-export { configFile, configFileIEO };
+export { configFile, configFileIEO, configTipBot, configTipBotWhitelistAddresses };

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,19 +1,22 @@
 // Use this on production
-import configFileProduction from '../config/files/config.json';
+/*import configFileProduction from '../config/files/config.json';
+import configFileIEOProduction from './files/config-ieo.json';
+import configTipBot from './files/settingsAssets.json';
+import configTipBotWhitelistAddresses from './files/settingsAssetsWhitelistAddresses.json';*/
 
 // import configFileProduction from '../config/files/config2.json';
 // Using this due to CI error
 // import configFileIEOProduction from './config-ieo.json';
+import configFileIEOProduction from './config-ieo.json';
 import configFileTest from './config-test.json';
-import configFileIEOProduction from './files/config-ieo.json';
-import configTipBot from './files/settingsAssets.json'
-import configTipBotWhitelistAddresses from './files/settingsAssetsWhitelistAddresses.json'
-// import configFileProduction from './config.json';
+import configFileProduction from './config.json';
+import configTipBot from './settingsAssets.json';
+import configTipBotWhitelistAddresses from './settingsAssetsWhitelistAddresses.json';
+
+// import configFileTest from './config-test.json';
 
 let configFile: any;
 let configFileIEO: any;
-
-
 
 if (process.env.NODE_ENV === 'test') {
     configFile = configFileTest;

--- a/src/config/settingsAssets.json
+++ b/src/config/settingsAssets.json
@@ -1,0 +1,671 @@
+{
+    "coins": {
+        "eth": {
+            "ticker": "ETH",
+            "name": "Ether",
+            "minimumWithdrawalCharge": 0.001,
+            "maximumWithdrawalCharge": 0.002,
+            "decimals": 18
+        }
+    },
+    "tokens": {
+        "vsf": {
+            "ticker": "VSF",
+            "name": "VeriSafe",
+            "mainnet-contract": "0xac9ce326e95f51b5005e9fe1dd8085a01f18450c",
+            "testnet-contract": "0x29fb74adb604cd520892443299e36cb3b4b23b62",
+            "contract": "0xac9ce326e95f51b5005e9fe1dd8085a01f18450c",
+            "info": "https://t.me/VeriSafe",
+            "minimumWithdrawalCharge": 20000,
+            "maximumWithdrawalCharge": 50000,
+            "decimals": 18,
+            "games": {
+                "dice": {
+                    "houseFee": 3,
+                    "minTokens": 1000,
+                    "maxTokens": 10000,
+                    "name": "VeriDice"
+                },
+                "flipLite": {
+                    "houseFee": 3,
+                    "minTokens": 1000,
+                    "maxTokens": 10000,
+                    "name": "VeriFlipLite"
+                },
+                "flip": {
+                    "houseFee": 3,
+                    "minTokens": 1000,
+                    "maxTokens": 10000,
+                    "name": "VeriFlip"
+                },
+                "roulette": {
+                    "houseFee": 2,
+                    "minTokens": 1000,
+                    "maxTokens": 10000,
+                    "name": "VeriSpin"
+                }
+            }
+        },
+        "vsffree": {
+            "ticker": "VSFFree",
+            "name": "VeriSafe (Free giveaway)",
+            "mainnet-contract": "0xac9ce326e95f51b5005e9fe1dd8085a01f18450c",
+            "testnet-contract": "0x29fb74adb604cd520892443299e36cb3b4b23b62",
+            "contract": "0xac9ce326e95f51b5005e9fe1dd8085a01f18450c",
+            "info": "https://t.me/VeriSafe",
+            "ethOnly": true,
+            "events": false,
+            "minimumWithdrawalCharge": 100000000,
+            "minimumWithdrawal": 1,
+            "maximumWithdrawalCharge": 200000000,
+            "maximumWithdrawal": 10000,
+            "decimals": 18
+        },
+        "vsfblackfriday": {
+            "ticker": "VSFBlackFriday",
+            "name": "VeriSafe (Black Friday)",
+            "mainnet-contract": "0xac9ce326e95f51b5005e9fe1dd8085a01f18450c",
+            "testnet-contract": "0x29fb74adb604cd520892443299e36cb3b4b23b62",
+            "contract": "0xac9ce326e95f51b5005e9fe1dd8085a01f18450c",
+            "info": "https://t.me/VeriSafe",
+            "ethOnly": true,
+            "events": false,
+            "minimumWithdrawalCharge": 100000000,
+            "minimumWithdrawal": 1,
+            "maximumWithdrawalCharge": 200000000,
+            "maximumWithdrawal": 10000,
+            "decimals": 18
+        },
+        "zeus": {
+            "ticker": "ZEUS",
+            "name": "Zeus",
+            "mainnet-contract": "0xe7e4279b80d319ede2889855135a22021baf0907",
+            "testnet-contract": "0x6A8094D90177bC60c30A8B895bce616Be7496427",
+            "contract": "0xe7e4279b80d319ede2889855135a22021baf0907",
+            "info": "https://t.me/ZeusCrowdfundingOfficial",
+            "ethOnly": true,
+            "minimumWithdrawalCharge": 200000,
+            "maximumWithdrawalCharge": 600000,
+            "decimals": 18,
+            "games": {
+                "dice": {
+                    "houseFee": 3,
+                    "minTokens": 1000,
+                    "maxTokens": 10000,
+                    "name": "ZeusDice"
+                }
+            }
+        },
+        "pop": {
+            "ticker": "POP",
+            "name": "POP Network",
+            "mainnet-contract": "0x5d858bcd53e085920620549214a8b27ce2f04670",
+            "testnet-contract": "0xdcebdfeee909d27c9353c69d036ecee5e3489049",
+            "contract": "0x5d858bcd53e085920620549214a8b27ce2f04670",
+            "info": "https://t.me/popnetwork",
+            "ethOnly": true,
+            "minimumWithdrawalCharge": 10000,
+            "maximumWithdrawalCharge": 20000,
+            "decimals": 18,
+            "games": {
+                "dice": {
+                    "houseFee": 3,
+                    "minTokens": 100,
+                    "maxTokens": 1000,
+                    "name": "PopDice"
+                }
+            }
+        },
+        "dpc": {
+            "ticker": "DPC",
+            "name": "Dan Pan Coin",
+            "mainnet-contract": "0xd434e2ec93be12d72934543f68278c2b8e0cb3fc",
+            "testnet-contract": "0xdcebdfeee909d27c9353c69d036ecee5e3489049",
+            "contract": "0xd434e2ec93be12d72934543f68278c2b8e0cb3fc",
+            "info": "",
+            "ethOnly": true,
+            "minimumWithdrawalCharge": 100000,
+            "maximumWithdrawalCharge": 300000,
+            "decimals": 2,
+            "games": {
+                "dice": {
+                    "houseFee": 3,
+                    "minTokens": 1000,
+                    "maxTokens": 10000,
+                    "name": "DanDice"
+                }
+            }
+        },
+        "tuck": {
+            "ticker": "TUCK",
+            "name": "Tuckermint",
+            "mainnet-contract": "0x8bde81dd5e30b058b71362b50fad06e3fdace640",
+            "testnet-contract": "0xdcebdfeee909d27c9353c69d036ecee5e3489049",
+            "contract": "0x8bde81dd5e30b058b71362b50fad06e3fdace640",
+            "info": "https://t.me/tuckermintchat",
+            "ethOnly": true,
+            "minimumWithdrawalCharge": 300000,
+            "maximumWithdrawalCharge": 600000,
+            "decimals": 18,
+            "games": {
+                "dice": {
+                    "houseFee": 3,
+                    "minTokens": 1000,
+                    "maxTokens": 10000,
+                    "name": "TuckDice"
+                }
+            }
+        },
+        "rxt": {
+            "ticker": "RXT",
+            "name": "RaptorXchange",
+            "mainnet-contract": "0x4bFFD10cF632E6c37214D19Fec8C343ed0a7BDc5",
+            "testnet-contract": "0xdcebdfeee909d27c9353c69d036ecee5e3489049",
+            "contract": "0x4bFFD10cF632E6c37214D19Fec8C343ed0a7BDc5",
+            "info": "https://t.me/raptorXchange",
+            "ethOnly": true,
+            "minimumWithdrawalCharge": 30,
+            "maximumWithdrawalCharge": 100,
+            "decimals": 8,
+            "games": {
+                "dice": {
+                    "houseFee": 1,
+                    "minTokens": 1,
+                    "maxTokens": 10,
+                    "name": "RaptorDice"
+                }
+            }
+        },
+        "0xbtc": {
+            "ticker": "0xBTC",
+            "name": "0xBitcoin",
+            "mainnet-contract": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
+            "testnet-contract": "0xdcebdfeee909d27c9353c69d036ecee5e3489049",
+            "contract": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
+            "info": "https://t.me/ZEROxBTC",
+            "ethOnly": true,
+            "minimumWithdrawalCharge": 40,
+            "maximumWithdrawalCharge": 100,
+            "decimals": 8,
+            "games": {
+                "dice": {
+                    "houseFee": 2,
+                    "minTokens": 0.1,
+                    "maxTokens": 10,
+                    "name": "0xBtcDice"
+                }
+            }
+        },
+        "void": {
+            "ticker": "VOID",
+            "name": "Void Token",
+            "mainnet-contract": "0xb8796542765747ed7f921ff12faff057b5d624d7",
+            "testnet-contract": "0xdcebdfeee909d27c9353c69d036ecee5e3489049",
+            "contract": "0xb8796542765747ed7f921ff12faff057b5d624d7",
+            "info": "https://t.me/thevoidtokenchat",
+            "ethOnly": true,
+            "minimumWithdrawalCharge": 1000,
+            "maximumWithdrawalCharge": 2000,
+            "decimals": 18,
+            "games": {
+                "dice": {
+                    "houseFee": 2,
+                    "minTokens": 1,
+                    "maxTokens": 10,
+                    "name": "VoidDice"
+                }
+            }
+        },
+        "vya": {
+            "ticker": "VYA",
+            "name": "VAYLA Token",
+            "mainnet-contract": "0x7b53b2c4b2f495d843a4e92e5c5511034d32bd15",
+            "testnet-contract": "0xdcebdfeee909d27c9353c69d036ecee5e3489049",
+            "contract": "0x7b53b2c4b2f495d843a4e92e5c5511034d32bd15",
+            "info": "https://t.me/VAYLAtoken",
+            "ethOnly": true,
+            "minimumWithdrawalCharge": 1000000000,
+            "maximumWithdrawalCharge": 10000000000,
+            "decimals": 8,
+            "games": {
+                "dice": {
+                    "houseFee": 2,
+                    "minTokens": 1000,
+                    "maxTokens": 100000,
+                    "name": "VaylaDice"
+                }
+            }
+        },
+        "vdex": {
+            "ticker": "VDEX",
+            "name": "VAYLA DEX",
+            "mainnet-contract": "0x3Fe1c06061F3EA23f4Aa771Ed33Cf878486CF214",
+            "testnet-contract": "0xdcebdfeee909d27c9353c69d036ecee5e3489049",
+            "contract": "0x3Fe1c06061F3EA23f4Aa771Ed33Cf878486CF214",
+            "info": "https://t.me/VAYLADEX",
+            "ethOnly": true,
+            "minimumWithdrawalCharge": 1000000000,
+            "maximumWithdrawalCharge": 10000000000,
+            "decimals": 18,
+            "games": {
+                "dice": {
+                    "houseFee": 2,
+                    "minTokens": 1000,
+                    "maxTokens": 100000,
+                    "name": "VdexDice"
+                }
+            }
+        },
+        "angel": {
+            "ticker": "ANGEL",
+            "name": "ANGEL Token",
+            "mainnet-contract": "0x6386db8bbb746b03ca96bb394b1dc3f7ed1c280c",
+            "testnet-contract": "0xdcebdfeee909d27c9353c69d036ecee5e3489049",
+            "contract": "0x6386db8bbb746b03ca96bb394b1dc3f7ed1c280c",
+            "info": "https://t.me/angeltoken01",
+            "ethOnly": true,
+            "minimumWithdrawalCharge": 200,
+            "maximumWithdrawalCharge": 1000,
+            "decimals": 18,
+            "games": {
+                "dice": {
+                    "houseFee": 2,
+                    "minTokens": 0.1,
+                    "maxTokens": 5,
+                    "name": "ANGELDice"
+                }
+            }
+        },
+        "mia": {
+            "ticker": "MIA",
+            "name": "Miasma",
+            "mainnet-contract": "0xa52d617149ba4dd280a1d76fe3821c4547a382c9",
+            "testnet-contract": "0xdcebdfeee909d27c9353c69d036ecee5e3489049",
+            "contract": "0xa52d617149ba4dd280a1d76fe3821c4547a382c9",
+            "info": "https://t.me/MiasmaAirdrop",
+            "ethOnly": true,
+            "minimumWithdrawalCharge": 200000,
+            "maximumWithdrawalCharge": 800000,
+            "decimals": 18,
+            "games": {
+                "dice": {
+                    "houseFee": 2,
+                    "minTokens": 10,
+                    "maxTokens": 10000,
+                    "name": "MiaDice"
+                }
+            }
+        },
+        "sam": {
+            "ticker": "SAM",
+            "name": "Sambam",
+            "mainnet-contract": "0x834b93f19dfb9c1966b3e1f3528da944e607f2cf",
+            "testnet-contract": "0xdcebdfeee909d27c9353c69d036ecee5e3489049",
+            "contract": "0x834b93f19dfb9c1966b3e1f3528da944e607f2cf",
+            "info": "",
+            "ethOnly": true,
+            "minimumWithdrawalCharge": 100000000,
+            "maximumWithdrawalCharge": 100000000,
+            "decimals": 18,
+            "games": {
+                "dice": {
+                    "houseFee": 2,
+                    "minTokens": 100,
+                    "maxTokens": 10000,
+                    "name": "SamDice"
+                }
+            }
+        },
+        "triz": {
+            "ticker": "TRIZ",
+            "name": "Tribezcoin",
+            "mainnet-contract": "0x2F8a2c9328CB0955EE363C4A7eA65974E1F55b03",
+            "testnet-contract": "0xdcebdfeee909d27c9353c69d036ecee5e3489049",
+            "contract": "0x2F8a2c9328CB0955EE363C4A7eA65974E1F55b03",
+            "info": "https://t.me/tribezcoin_id",
+            "ethOnly": true,
+            "minimumWithdrawalCharge": 100000000,
+            "maximumWithdrawalCharge": 100000000,
+            "decimals": 6,
+            "games": {
+                "dice": {
+                    "houseFee": 2,
+                    "minTokens": 10,
+                    "maxTokens": 10000,
+                    "name": "TrizDice"
+                }
+            }
+        },
+        "rbc": {
+            "ticker": "RBC",
+            "name": "Rambocoin",
+            "mainnet-contract": "0x398E616B74832f26FB342913E0d81FFfeF70fb71",
+            "testnet-contract": "0xdcebdfeee909d27c9353c69d036ecee5e3489049",
+            "contract": "0x398E616B74832f26FB342913E0d81FFfeF70fb71",
+            "info": "",
+            "ethOnly": true,
+            "minimumWithdrawalCharge": 1000000000,
+            "maximumWithdrawalCharge": 1000000000,
+            "decimals": 18,
+            "games": {
+                "dice": {
+                    "houseFee": 2,
+                    "minTokens": 10,
+                    "maxTokens": 10000,
+                    "name": "RamboDice"
+                }
+            }
+        },
+        "ldex": {
+            "ticker": "LDEX",
+            "name": "LogicDEX Token",
+            "mainnet-contract": "0xb1d22dffb6c9bf70544116b3ce784454cf383577",
+            "testnet-contract": "0xdcebdfeee909d27c9353c69d036ecee5e3489049",
+            "contract": "0xb1d22dffb6c9bf70544116b3ce784454cf383577",
+            "info": "",
+            "ethOnly": true,
+            "minimumWithdrawalCharge": 1000000000,
+            "maximumWithdrawalCharge": 1000000000,
+            "decimals": 18,
+            "games": {
+                "dice": {
+                    "houseFee": 2,
+                    "minTokens": 10,
+                    "maxTokens": 10000,
+                    "name": "LogicDice"
+                }
+            }
+        },
+        "idn": {
+            "ticker": "IDN",
+            "name": "Indonesian Project",
+            "mainnet-contract": "0x70Ec7702ADA8530d8f7332f7f3700099553D772D",
+            "testnet-contract": "0x70Ec7702ADA8530d8f7332f7f3700099553D772D",
+            "contract": "0x70Ec7702ADA8530d8f7332f7f3700099553D772D",
+            "info": "https://t.me/IDNProject_TOKEN",
+            "ethOnly": true,
+            "minimumWithdrawalCharge": 100000000,
+            "maximumWithdrawalCharge": 100000000,
+            "decimals": 8,
+            "games": {
+                "dice": {
+                    "houseFee": 2,
+                    "minTokens": 10,
+                    "maxTokens": 10000,
+                    "name": "IDNDice"
+                }
+            }
+        },
+        "ash": {
+            "ticker": "ASH",
+            "name": "Ash",
+            "mainnet-contract": "0x71590d4ed14d9cbacb2cff8abf919ac4d22c5b7b",
+            "testnet-contract": "0xdcebdfeee909d27c9353c69d036ecee5e3489049",
+            "contract": "0x71590d4ed14d9cbacb2cff8abf919ac4d22c5b7b",
+            "info": "https://t.me/ASHToken",
+            "ethOnly": true,
+            "minimumWithdrawalCharge": 1000000,
+            "maximumWithdrawalCharge": 1000000,
+            "decimals": 18,
+            "games": {
+                "dice": {
+                    "houseFee": 2,
+                    "minTokens": 1,
+                    "maxTokens": 10,
+                    "name": "AshDice"
+                }
+            }
+        },
+        "pixby": {
+            "ticker": "PIXBY",
+            "name": "PIXBY",
+            "mainnet-contract": "0xB53e08B97724126Bda6d237B94F766c0b81C90fE",
+            "testnet-contract": "0xdcebdfeee909d27c9353c69d036ecee5e3489049",
+            "contract": "0xB53e08B97724126Bda6d237B94F766c0b81C90fE",
+            "info": "https://t.me/pixbytoken",
+            "ethOnly": true,
+            "minimumWithdrawalCharge": 1000000,
+            "maximumWithdrawalCharge": 1000000,
+            "decimals": 18,
+            "games": {
+                "dice": {
+                    "houseFee": 2,
+                    "minTokens": 10,
+                    "maxTokens": 10000,
+                    "name": "PIXBYDice"
+                }
+            }
+        },
+        "nuk": {
+            "ticker": "NUK",
+            "name": "NUKlear",
+            "mainnet-contract": "0x9E12c837159deDc233719EDf5A4eC2405644E8a7",
+            "testnet-contract": "0xdcebdfeee909d27c9353c69d036ecee5e3489049",
+            "contract": "0x9E12c837159deDc233719EDf5A4eC2405644E8a7",
+            "info": "https://t.me/nuklear_official",
+            "ethOnly": true,
+            "minimumWithdrawalCharge": 1000000,
+            "maximumWithdrawalCharge": 1000000,
+            "decimals": 3,
+            "games": {
+                "dice": {
+                    "houseFee": 2,
+                    "minTokens": 1,
+                    "maxTokens": 20,
+                    "name": "NukDice"
+                }
+            }
+        },
+        "muxe": {
+            "ticker": "MUXE",
+            "name": "MUXE Token",
+            "mainnet-contract": "0x515669d308f887fd83a471c7764f5d084886d34d",
+            "testnet-contract": "0xdcebdfeee909d27c9353c69d036ecee5e3489049",
+            "contract": "0x515669d308f887fd83a471c7764f5d084886d34d",
+            "info": "https://t.me/muxebv",
+            "ethOnly": true,
+            "minimumWithdrawalCharge": 1000000,
+            "maximumWithdrawalCharge": 1000000,
+            "decimals": 18,
+            "games": {
+                "dice": {
+                    "houseFee": 2,
+                    "minTokens": 100,
+                    "maxTokens": 20000,
+                    "name": "MuxeDice"
+                }
+            }
+        },
+        "seol": {
+            "ticker": "SEOL",
+            "name": "SEEDOFLOVE",
+            "mainnet-contract": "0xd907daeed4dae963b0e2442e330d1760d752a68e",
+            "testnet-contract": "0xdcebdfeee909d27c9353c69d036ecee5e3489049",
+            "contract": "0xd907daeed4dae963b0e2442e330d1760d752a68e",
+            "info": "https://t.me/seedoflovetoken",
+            "ethOnly": true,
+            "minimumWithdrawalCharge": 1855000000,
+            "maximumWithdrawalCharge": 1855000000,
+            "decimals": 18,
+            "games": {
+                "dice": {
+                    "houseFee": 2,
+                    "minTokens": 100,
+                    "maxTokens": 20000,
+                    "name": "SeolDice"
+                }
+            }
+        },
+        "wwt": {
+            "ticker": "WWT",
+            "name": "World Wide Trade",
+            "mainnet-contract": "0x512630DC263FD4c71DBe81Fec68cF61156d79E80",
+            "testnet-contract": "0xdcebdfeee909d27c9353c69d036ecee5e3489049",
+            "contract": "0x512630DC263FD4c71DBe81Fec68cF61156d79E80",
+            "info": "https://t.me/worldwidetradeWWT",
+            "ethOnly": true,
+            "minimumWithdrawalCharge": 10000000,
+            "maximumWithdrawalCharge": 10000000,
+            "decimals": 18,
+            "games": {
+                "dice": {
+                    "houseFee": 3,
+                    "minTokens": 10,
+                    "maxTokens": 2000,
+                    "name": "WWTDice"
+                }
+            }
+        },
+        "ltn": {
+            "ticker": "LTN",
+            "name": "LotanCoin",
+            "mainnet-contract": "0x6f4bea736cc51f6dcfdead130aa3acc9551f6421",
+            "testnet-contract": "0xdcebdfeee909d27c9353c69d036ecee5e3489049",
+            "contract": "0x6f4bea736cc51f6dcfdead130aa3acc9551f6421",
+            "info": "https://t.me/lotanchain",
+            "ethOnly": true,
+            "minimumWithdrawalCharge": 10000000,
+            "maximumWithdrawalCharge": 10000000,
+            "decimals": 8,
+            "games": {
+                "dice": {
+                    "houseFee": 3,
+                    "minTokens": 10,
+                    "maxTokens": 2000,
+                    "name": "LotanDice"
+                }
+            }
+        },
+        "bcp": {
+            "ticker": "BCP",
+            "name": "bitcoinplatinums",
+            "mainnet-contract": "0xd26fb114401ec86887cd09f62eccd95fcf20b571",
+            "testnet-contract": "0xdcebdfeee909d27c9353c69d036ecee5e3489049",
+            "contract": "0xd26fb114401ec86887cd09f62eccd95fcf20b571",
+            "info": "https://t.me/bitcoinplatinumsexchange",
+            "ethOnly": true,
+            "minimumWithdrawalCharge": 10000000,
+            "maximumWithdrawalCharge": 10000000,
+            "decimals": 8,
+            "games": {
+                "dice": {
+                    "houseFee": 3,
+                    "minTokens": 1,
+                    "maxTokens": 20,
+                    "name": "BCPDice"
+                }
+            }
+        },
+        "chess": {
+            "ticker": "CHESS",
+            "name": "Chess Coin",
+            "mainnet-contract": "0x5f75112bBB4E1aF516fBE3e21528C63DA2B6a1A5",
+            "testnet-contract": "0xdcebdfeee909d27c9353c69d036ecee5e3489049",
+            "contract": "0x5f75112bBB4E1aF516fBE3e21528C63DA2B6a1A5",
+            "info": "http://t.me/BrainiacChess_Network",
+            "ethOnly": true,
+            "minimumWithdrawalCharge": 10000000,
+            "maximumWithdrawalCharge": 10000000,
+            "decimals": 18,
+            "games": {
+                "dice": {
+                    "houseFee": 3,
+                    "minTokens": 1,
+                    "maxTokens": 20,
+                    "name": "ChessDice"
+                }
+            }
+        },
+        "whackd": {
+            "ticker": "WHACKD",
+            "name": "Whackd",
+            "mainnet-contract": "0xcf8335727b776d190f9d15a54e6b9b9348439eee",
+            "testnet-contract": "0xdcebdfeee909d27c9353c69d036ecee5e3489049",
+            "contract": "0xcf8335727b776d190f9d15a54e6b9b9348439eee",
+            "info": "https://t.me/whackdtokens",
+            "ethOnly": true,
+            "minimumWithdrawalCharge": 10000000,
+            "maximumWithdrawalCharge": 10000000,
+            "decimals": 18,
+            "games": {
+                "dice": {
+                    "houseFee": 3,
+                    "minTokens": 1,
+                    "maxTokens": 20,
+                    "name": "WhackDice"
+                }
+            }
+        },
+        "ethbold": {
+            "ticker": "ETHBOLD",
+            "name": "ETHBOLD",
+            "mainnet-contract": "0x9f9a0e0747a18426fd29f4a76820c808da3b140b",
+            "testnet-contract": "0xdcebdfeee909d27c9353c69d036ecee5e3489049",
+            "contract": "0x9f9a0e0747a18426fd29f4a76820c808da3b140b",
+            "info": "https://t.me/ETHBOLD_Official",
+            "ethOnly": true,
+            "minimumWithdrawalCharge": 10000000,
+            "maximumWithdrawalCharge": 10000000,
+            "decimals": 18,
+            "games": {
+                "dice": {
+                    "houseFee": 3,
+                    "minTokens": 1,
+                    "maxTokens": 20,
+                    "name": "EthBoldDice"
+                }
+            }
+        },
+        "bdax": {
+            "ticker": "BDAX",
+            "name": "BoldDax",
+            "mainnet-contract": "0xE6B9018365cE008319DF4Dec715E664B3CC93321",
+            "testnet-contract": "0xdcebdfeee909d27c9353c69d036ecee5e3489049",
+            "contract": "0xE6B9018365cE008319DF4Dec715E664B3CC93321",
+            "info": "https://t.me/BoldDax",
+            "ethOnly": true,
+            "minimumWithdrawalCharge": 10000000,
+            "maximumWithdrawalCharge": 10000000,
+            "decimals": 18,
+            "games": {
+                "dice": {
+                    "houseFee": 3,
+                    "minTokens": 1,
+                    "maxTokens": 20,
+                    "name": "BoldDice"
+                }
+            }
+        },
+        "defl": {
+            "ticker": "DEFL",
+            "name": "Deflacoin",
+            "mainnet-contract": "0x4ec2efb9cbd374786a03261e46ffce1a67756f3b",
+            "testnet-contract": "0xdcebdfeee909d27c9353c69d036ecee5e3489049",
+            "contract": "0x4ec2efb9cbd374786a03261e46ffce1a67756f3b",
+            "info": "https://t.me/deflacoin",
+            "ethOnly": true,
+            "minimumWithdrawalCharge": 10000000,
+            "maximumWithdrawalCharge": 10000000,
+            "decimals": 18,
+            "games": {
+                "dice": {
+                    "houseFee": 3,
+                    "minTokens": 1,
+                    "maxTokens": 20,
+                    "name": "DefDice"
+                }
+            }
+        },
+        "weth": {
+            "ticker": "WETH",
+            "name": "Wrapped Ether",
+            "mainnet-contract": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "testnet-contract": "0xdcebdfeee909d27c9353c69d036ecee5e3489049",
+            "contract": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "info": "https://weth.io/",
+            "minimumWithdrawalCharge": 0.0006,
+            "maximumWithdrawalCharge": 0.0018,
+            "decimals": 18
+        }
+    }
+}

--- a/src/config/settingsAssetsWhitelistAddresses.json
+++ b/src/config/settingsAssetsWhitelistAddresses.json
@@ -1,0 +1,5 @@
+{
+    "defaultWhitelistAddresses": ["0x5265bde27f57e738be6c1f6ab3544e82cdc92a8f"],
+    "defaultFeePercentage": 0.01,
+    "tokens": {}
+}

--- a/src/services/relayer.ts
+++ b/src/services/relayer.ts
@@ -215,7 +215,7 @@ export const getUserIEOSignedOrders = async (
     const quoteAssetData = assetDataUtils.encodeERC20AssetData(quoteToken.address);
 
     const response = await fetch(
-        `${RELAYER_URL}/ieo_orders?makerAssetData=${baseAssetData}&takerAssetData=${quoteAssetData}&makerAddress=${makerAddress}`,
+        `${RELAYER_URL}/ieo_orders?makerAssetData=${baseAssetData}&takerAssetData=${quoteAssetData}&makerAddress=${makerAddress.toLowerCase()}`,
         init,
     );
     if (response.ok) {

--- a/src/store/blockchain/actions.ts
+++ b/src/store/blockchain/actions.ts
@@ -5,10 +5,7 @@ import { createAction, createAsyncAction } from 'typesafe-actions';
 import { COLLECTIBLE_ADDRESS, FEE_RECIPIENT, NETWORK_ID, START_BLOCK_LIMIT } from '../../common/constants';
 import { ConvertBalanceMustNotBeEqualException } from '../../exceptions/convert_balance_must_not_be_equal_exception';
 import { SignedOrderException } from '../../exceptions/signed_order_exception';
-import {
-    subscribeToAllFillEvents,
-    subscribeToFillEvents,
-} from '../../services/exchange';
+import { subscribeToAllFillEvents, subscribeToFillEvents } from '../../services/exchange';
 import { getGasEstimationInfoAsync } from '../../services/gas_price_estimation';
 import { LocalStorage } from '../../services/local_storage';
 import { tokensToTokenBalances, tokenToTokenBalance } from '../../services/tokens';

--- a/src/store/relayer/actions.ts
+++ b/src/store/relayer/actions.ts
@@ -22,6 +22,7 @@ import { isWeth } from '../../util/known_tokens';
 import { getLogger } from '../../util/logger';
 import {
     buildLimitOrder,
+    buildLimitOrderIEO,
     buildMarketLimitMatchingOrders,
     buildMarketOrders,
     sumTakerAssetFillableOrders,
@@ -512,7 +513,7 @@ export const fetchTakerAndMakerFeeIEO: ThunkCreator<Promise<{ makerFee: BigNumbe
         const quoteToken = quoteTokenBalance.token;
         const contractWrappers = await getContractWrappers();
 
-        const order = await buildLimitOrder(
+        const order = await buildLimitOrderIEO(
             {
                 account: ethAccount,
                 amount,

--- a/src/util/known_tokens_ieo.ts
+++ b/src/util/known_tokens_ieo.ts
@@ -1,12 +1,12 @@
 import { assetDataUtils, ExchangeFillEventArgs, LogWithDecodedArgs } from '0x.js';
 
+import { ConfigIEO } from '../common/config';
 import { KNOWN_TOKENS_META_DATA } from '../common/tokens_meta_data';
 import { KNOWN_TOKENS_IEO_META_DATA, TokenIEOMetaData } from '../common/tokens_meta_data_ieo';
 
 import { getLogger } from './logger';
-import { mapTokensIEOMetaDataToTokenByNetworkId, mapTokensBotToTokenIEO } from './token_ieo_meta_data';
+import { mapTokensBotToTokenIEO, mapTokensIEOMetaDataToTokenByNetworkId } from './token_ieo_meta_data';
 import { TokenIEO } from './types';
-import { ConfigIEO } from '../common/config';
 
 const logger = getLogger('Tokens::known_tokens .ts');
 
@@ -53,6 +53,46 @@ export class KnownTokensIEO {
         const token = this._tokensBot.find(t => t.address.toLowerCase() === addressInLowerCase);
         if (!token) {
             throw new Error(`Token with address ${address} not found in known tokens`);
+        }
+        return token;
+    };
+    public getAllTokensByAddress = (address: string): TokenIEO => {
+        const addressInLowerCase = address.toLowerCase();
+        let token = this._tokensBot.find(t => t.address.toLowerCase() === addressInLowerCase);
+        if (!token) {
+            token = this._tokens.find(t => t.address.toLowerCase() === addressInLowerCase);
+        }
+        if (!token) {
+            throw new Error(`Token with address ${address} not found in known tokens`);
+        }
+        return token;
+    };
+
+    public getTokenBotByName = (name: string): TokenIEO => {
+        const nameInLowerCase = name.toLowerCase();
+        const token = this._tokensBot.find(t => t.name.toLowerCase() === nameInLowerCase);
+        if (!token) {
+            throw new Error(`Token with address ${name} not found in known tokens`);
+        }
+        return token;
+    };
+    public getTokenBotBySymbol = (symbol: string): TokenIEO => {
+        const symbolInLowerCase = symbol.toLowerCase();
+        const token = this._tokensBot.find(t => t.symbol.toLowerCase() === symbolInLowerCase);
+        if (!token) {
+            throw new Error(`Token with address ${symbol} not found in known tokens`);
+        }
+        return token;
+    };
+
+    public getAllTokensByName = (name: string): TokenIEO => {
+        const nameInLowerCase = name.toLowerCase();
+        let token = this._tokensBot.find(t => t.name.toLowerCase() === nameInLowerCase);
+        if (!token) {
+            token = this._tokens.find(t => t.name.toLowerCase() === nameInLowerCase);
+        }
+        if (!token) {
+            throw new Error(`Token with address ${name} not found in known tokens`);
         }
         return token;
     };

--- a/src/util/known_tokens_ieo.ts
+++ b/src/util/known_tokens_ieo.ts
@@ -4,16 +4,19 @@ import { KNOWN_TOKENS_META_DATA } from '../common/tokens_meta_data';
 import { KNOWN_TOKENS_IEO_META_DATA, TokenIEOMetaData } from '../common/tokens_meta_data_ieo';
 
 import { getLogger } from './logger';
-import { mapTokensIEOMetaDataToTokenByNetworkId } from './token_ieo_meta_data';
+import { mapTokensIEOMetaDataToTokenByNetworkId, mapTokensBotToTokenIEO } from './token_ieo_meta_data';
 import { TokenIEO } from './types';
+import { ConfigIEO } from '../common/config';
 
 const logger = getLogger('Tokens::known_tokens .ts');
 
 export class KnownTokensIEO {
     private readonly _tokens: TokenIEO[] = [];
+    private readonly _tokensBot: TokenIEO[] = [];
 
     constructor(knownTokensMetadata: TokenIEOMetaData[]) {
         this._tokens = mapTokensIEOMetaDataToTokenByNetworkId(knownTokensMetadata);
+        this._tokensBot = mapTokensBotToTokenIEO(ConfigIEO.getConfigBot().tokens);
     }
 
     public getTokenBySymbol = (symbol: string): TokenIEO => {
@@ -40,6 +43,14 @@ export class KnownTokensIEO {
     public getTokenByAddress = (address: string): TokenIEO => {
         const addressInLowerCase = address.toLowerCase();
         const token = this._tokens.find(t => t.address.toLowerCase() === addressInLowerCase);
+        if (!token) {
+            throw new Error(`Token with address ${address} not found in known tokens`);
+        }
+        return token;
+    };
+    public getTokenBotByAddress = (address: string): TokenIEO => {
+        const addressInLowerCase = address.toLowerCase();
+        const token = this._tokensBot.find(t => t.address.toLowerCase() === addressInLowerCase);
         if (!token) {
             throw new Error(`Token with address ${address} not found in known tokens`);
         }

--- a/src/util/time_utils.ts
+++ b/src/util/time_utils.ts
@@ -10,6 +10,11 @@ export const getExpirationTimeOrdersFromConfig = () => {
     );
 };
 
+// Default to 120 days
+export const getExpirationTimeToBotOrders = () => {
+    return new BigNumber(Math.floor(new Date().valueOf() / 1000) + 3600 * 24 * 120);
+};
+
 export const getExpirationTimeFromDate = (timestamp: number | string) => {
     return new BigNumber(Math.floor(new Date(timestamp).valueOf() / 1000));
 };

--- a/src/util/token_ieo_meta_data.ts
+++ b/src/util/token_ieo_meta_data.ts
@@ -1,7 +1,7 @@
 import { NETWORK_ID, UI_DECIMALS_DISPLAYED_DEFAULT_PRECISION } from '../common/constants';
 import { TokenIEOMetaData } from '../common/tokens_meta_data_ieo';
 
-import { TokenIEO, AssetBot } from './types';
+import { AssetBot, TokenIEO } from './types';
 
 export const mapTokensIEOMetaDataToTokenByNetworkId = (tokensMetaData: TokenIEOMetaData[]): TokenIEO[] => {
     return tokensMetaData
@@ -48,41 +48,39 @@ export const mapTokensIEOMetaDataToTokenByNetworkId = (tokensMetaData: TokenIEOM
         );
 };
 
-
 export const mapTokensBotToTokenIEO = (assetTokens: AssetBot[]): TokenIEO[] => {
-    return assetTokens
-        .map(
-            (asset): AssetBot => {
-                return {
-                    address: asset.contract,
-                    symbol: asset.ticker,
-                    decimals: asset.decimals,
-                    name: asset.name,
-                    primaryColor: '#fff',
-                    icon: undefined,
-                    displayDecimals: UI_DECIMALS_DISPLAYED_DEFAULT_PRECISION,
-                    id: undefined,
-                    c_id: undefined,
-                    minAmount:  0,
-                    maxAmount:  undefined,
-                    precision: UI_DECIMALS_DISPLAYED_DEFAULT_PRECISION,
-                    website:  undefined,
-                    description:  undefined,
-                    verisafe_sticker:  undefined,
-                    owners: asset.whitelistAddresses,
-                    social: {
-                        facebook_url:  undefined,
-                        reddit_url: undefined,
-                        twitter_url: undefined,
-                        telegram_url: undefined,
-                        discord_url: undefined,
-                        bitcointalk_url: undefined,
-                        youtube_url:  undefined,
-                        medium_url: undefined,
-                    },
-                    feePercentage: asset.feePercentage,
-                    endDate:  undefined,
-                };
-            },
-        );
+    return assetTokens.map(
+        (asset): TokenIEO => {
+            return {
+                address: asset.contract,
+                symbol: asset.ticker,
+                decimals: asset.decimals,
+                name: asset.name,
+                primaryColor: '#000',
+                icon: undefined,
+                displayDecimals: UI_DECIMALS_DISPLAYED_DEFAULT_PRECISION,
+                id: undefined,
+                c_id: undefined,
+                minAmount: 0,
+                maxAmount: undefined,
+                precision: UI_DECIMALS_DISPLAYED_DEFAULT_PRECISION,
+                website: undefined,
+                description: undefined,
+                verisafe_sticker: undefined,
+                owners: asset.whitelistAddresses,
+                social: {
+                    facebook_url: undefined,
+                    reddit_url: undefined,
+                    twitter_url: undefined,
+                    telegram_url: undefined,
+                    discord_url: undefined,
+                    bitcointalk_url: undefined,
+                    youtube_url: undefined,
+                    medium_url: undefined,
+                },
+                feePercentage: asset.feePercentage,
+                endDate: undefined,
+            };
+        },
+    );
 };

--- a/src/util/token_ieo_meta_data.ts
+++ b/src/util/token_ieo_meta_data.ts
@@ -1,7 +1,7 @@
 import { NETWORK_ID, UI_DECIMALS_DISPLAYED_DEFAULT_PRECISION } from '../common/constants';
 import { TokenIEOMetaData } from '../common/tokens_meta_data_ieo';
 
-import { TokenIEO } from './types';
+import { TokenIEO, AssetBot } from './types';
 
 export const mapTokensIEOMetaDataToTokenByNetworkId = (tokensMetaData: TokenIEOMetaData[]): TokenIEO[] => {
     return tokensMetaData
@@ -43,6 +43,45 @@ export const mapTokensIEOMetaDataToTokenByNetworkId = (tokensMetaData: TokenIEOM
                     },
                     feePercentage: tokenMetaData.feePercentage || undefined,
                     endDate: tokenMetaData.endDate || undefined,
+                };
+            },
+        );
+};
+
+
+export const mapTokensBotToTokenIEO = (assetTokens: AssetBot[]): TokenIEO[] => {
+    return assetTokens
+        .map(
+            (asset): AssetBot => {
+                return {
+                    address: asset.contract,
+                    symbol: asset.ticker,
+                    decimals: asset.decimals,
+                    name: asset.name,
+                    primaryColor: '#fff',
+                    icon: undefined,
+                    displayDecimals: UI_DECIMALS_DISPLAYED_DEFAULT_PRECISION,
+                    id: undefined,
+                    c_id: undefined,
+                    minAmount:  0,
+                    maxAmount:  undefined,
+                    precision: UI_DECIMALS_DISPLAYED_DEFAULT_PRECISION,
+                    website:  undefined,
+                    description:  undefined,
+                    verisafe_sticker:  undefined,
+                    owners: asset.whitelistAddresses,
+                    social: {
+                        facebook_url:  undefined,
+                        reddit_url: undefined,
+                        twitter_url: undefined,
+                        telegram_url: undefined,
+                        discord_url: undefined,
+                        bitcointalk_url: undefined,
+                        youtube_url:  undefined,
+                        medium_url: undefined,
+                    },
+                    feePercentage: asset.feePercentage,
+                    endDate:  undefined,
                 };
             },
         );

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -8,7 +8,6 @@ import { TokenMetaData } from '../common/tokens_meta_data';
 import { TokenIEOMetaData } from '../common/tokens_meta_data_ieo';
 import { ExtraArgument } from '../store/index';
 import { ThemeModalStyle, ThemeProperties } from '../themes/commons';
-import { string } from 'prop-types';
 
 export interface TabItem {
     active: boolean;
@@ -602,15 +601,14 @@ export interface ConfigFileTipBot {
     tokens: AssetBot[];
 }
 
-export interface AssetBot{
+export interface AssetBot {
     ticker: string;
     name: string;
     contract: string;
     decimals: number;
     whitelistAddresses: string[];
-    feePercentage: number;
+    feePercentage: string;
 }
-
 
 export enum Browser {
     Chrome = 'CHROME',

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -8,6 +8,7 @@ import { TokenMetaData } from '../common/tokens_meta_data';
 import { TokenIEOMetaData } from '../common/tokens_meta_data_ieo';
 import { ExtraArgument } from '../store/index';
 import { ThemeModalStyle, ThemeProperties } from '../themes/commons';
+import { string } from 'prop-types';
 
 export interface TabItem {
     active: boolean;
@@ -596,6 +597,20 @@ export interface ConfigFile {
 export interface ConfigFileIEO {
     tokens: TokenIEOMetaData[];
 }
+
+export interface ConfigFileTipBot {
+    tokens: AssetBot[];
+}
+
+export interface AssetBot{
+    ticker: string;
+    name: string;
+    contract: string;
+    decimals: number;
+    whitelistAddresses: string[];
+    feePercentage: number;
+}
+
 
 export enum Browser {
     Chrome = 'CHROME',

--- a/src/util/ui_orders.ts
+++ b/src/util/ui_orders.ts
@@ -184,7 +184,7 @@ const ordersToIEOUIOrdersWithOrdersInfo = (
         const size = isSell ? order.makerAssetAmount : order.takerAssetAmount;
 
         const makerAssetAddress = assetDataUtils.decodeERC20AssetData(order.makerAssetData).tokenAddress;
-        const makerAssetTokenDecimals = getKnownTokensIEO().getTokenByAddress(makerAssetAddress).decimals;
+        const makerAssetTokenDecimals = getKnownTokensIEO().getAllTokensByAddress(makerAssetAddress).decimals;
         const makerAssetAmountInUnits = tokenAmountInUnitsToBigNumber(order.makerAssetAmount, makerAssetTokenDecimals);
 
         const takerAssetAddress = assetDataUtils.decodeERC20AssetData(order.takerAssetData).tokenAddress;


### PR DESCRIPTION
Add instant support for all listed bot tokens.

When tipgram adds an asset, this asset will be listed on veridex with a buy link to be used by them on supported web3 wallets. Orders on the bot are whitelisted.

Instant buy link for each asset https://dex.verisafe.io/#/instant?symbol=tokenBotTicker&isBot=true or  https://dex.verisafe.io/#/instant?token=tokenBotName&isBot=true

Dashboard for whitelisted addresses:
https://dex.verisafe.io/#/launchpad/orders?symbol=tokenBotSymbol&bot=true
