### PR TITLE
Feature/enable server trade updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
         "source-map-explorer": "^2.1.0",
         "styled-components": "^4.1.3",
         "typesafe-actions": "^3.0.0",
-        "utility-types": "^3.8.0"
+        "utility-types": "^3.8.0",
+        "uuid": "^3.3.3"
     },
     "scripts": {
         "start": "cross-env PORT=3001 react-scripts start",

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -7,10 +7,14 @@ export const LAUNCHPAD_APP_BASE_PATH = '/launchpad';
 export const MARGIN_APP_BASE_PATH = '/margin';
 export const INSTANT_APP_BASE_PATH = '/instant';
 
+export const USE_RELAYER_MARKET_UPDATES = process.env.REACT_APP_USE_RELAYER_MARKET_UPDATES || false;
+
 export const ERC721_APP_BASE_PATH = '/erc721';
 export const DEFAULT_BASE_PATH = process.env.REACT_APP_DEFAULT_BASE_PATH || ERC20_APP_BASE_PATH;
 
 export const RELAYER_URL = process.env.REACT_APP_RELAYER_URL || 'http://localhost:3001/api/v2';
+
+export const RELAYER_WS_URL = process.env.REACT_APP_RELAYER_WS_URL || 'ws://localhost:3001';
 
 export const TX_DEFAULTS = {
     gasLimit: 1000000,

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -7,7 +7,7 @@ export const LAUNCHPAD_APP_BASE_PATH = '/launchpad';
 export const MARGIN_APP_BASE_PATH = '/margin';
 export const INSTANT_APP_BASE_PATH = '/instant';
 
-export const USE_RELAYER_MARKET_UPDATES = process.env.REACT_APP_USE_RELAYER_MARKET_UPDATES || false;
+export const USE_RELAYER_MARKET_UPDATES = process.env.REACT_APP_USE_RELAYER_MARKET_UPDATES === 'true' ? true : false;
 
 export const ERC721_APP_BASE_PATH = '/erc721';
 export const DEFAULT_BASE_PATH = process.env.REACT_APP_DEFAULT_BASE_PATH || ERC20_APP_BASE_PATH;

--- a/src/components/erc20/common/market_details.tsx
+++ b/src/components/erc20/common/market_details.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import styled from 'styled-components';
 
+import { USE_RELAYER_MARKET_UPDATES } from '../../../common/constants';
 import { changeMarket, goToHome } from '../../../store/actions';
 import {
     getBaseToken,
@@ -73,6 +74,22 @@ const statsToRow = (marketStats: MarketStats, baseToken: Token, currencyPair: Cu
     const lastPrice = marketStats.lastPrice
         ? new BigNumber(marketStats.lastPrice).toFixed(currencyPair.config.pricePrecision)
         : '-';
+    let volume;
+    if (USE_RELAYER_MARKET_UPDATES) {
+        volume =
+            (marketStats.volume &&
+                `${marketStats.volume.toFixed(baseToken.displayDecimals)} ${baseToken.symbol.toUpperCase()}`) ||
+            '- ';
+    } else {
+        volume =
+            (marketStats.volume &&
+                `${tokenAmountInUnits(
+                    marketStats.volume,
+                    baseToken.decimals,
+                    baseToken.displayDecimals,
+                ).toString()} ${baseToken.symbol.toUpperCase()}`) ||
+            '- ';
+    }
 
     return (
         <TR>
@@ -84,15 +101,7 @@ const statsToRow = (marketStats: MarketStats, baseToken: Token, currencyPair: Cu
             <CustomTD styles={{ textAlign: 'right', tabular: true }}>
                 {(marketStats.lowerPrice && marketStats.lowerPrice.toFixed(currencyPair.config.pricePrecision)) || '-'}
             </CustomTD>
-            <CustomTD styles={{ textAlign: 'right', tabular: true }}>
-                {(marketStats.volume &&
-                    `${tokenAmountInUnits(
-                        marketStats.volume,
-                        baseToken.decimals,
-                        baseToken.displayDecimals,
-                    ).toString()} ${baseToken.symbol.toUpperCase()}`) ||
-                    '-'}{' '}
-            </CustomTD>
+            <CustomTD styles={{ textAlign: 'right', tabular: true }}>{volume}</CustomTD>
             <CustomTD styles={{ textAlign: 'right', tabular: true }}>{marketStats.closedOrders || '-'}</CustomTD>
         </TR>
     );

--- a/src/components/erc20/marketplace/market_fills.tsx
+++ b/src/components/erc20/marketplace/market_fills.tsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import TimeAgo from 'react-timeago';
 import styled from 'styled-components';
 
+import { USE_RELAYER_MARKET_UPDATES } from '../../../common/constants';
 import { changeMarket, goToHome } from '../../../store/actions';
 import { getBaseToken, getMarketFills, getQuoteToken, getWeb3State } from '../../../store/selectors';
 import { getCurrencyPairByTokensSymbol } from '../../../util/known_currency_pairs';
@@ -41,14 +42,26 @@ export const SideTD = styled(CustomTD)<{ side: OrderSide }>`
 
 const fillToRow = (fill: Fill, index: number) => {
     const sideLabel = fill.side === OrderSide.Sell ? 'Sell' : 'Buy';
-    const amountBase = tokenAmountInUnits(fill.amountBase, fill.tokenBase.decimals, fill.tokenBase.displayDecimals);
+    let amountBase;
+    let amountQuote;
+    if (USE_RELAYER_MARKET_UPDATES) {
+        amountBase = fill.amountBase.toFixed(fill.tokenBase.displayDecimals);
+        amountQuote = fill.amountQuote.toFixed(fill.tokenQuote.displayDecimals);
+    } else {
+        amountBase = tokenAmountInUnits(fill.amountBase, fill.tokenBase.decimals, fill.tokenBase.displayDecimals);
+        amountQuote = tokenAmountInUnits(fill.amountQuote, fill.tokenQuote.decimals, fill.tokenQuote.displayDecimals);
+    }
+
     const displayAmountBase = `${amountBase} ${fill.tokenBase.symbol.toUpperCase()}`;
-    const amountQuote = tokenAmountInUnits(fill.amountQuote, fill.tokenQuote.decimals, fill.tokenQuote.displayDecimals);
+
     const tokenQuoteSymbol = isWeth(fill.tokenQuote.symbol) ? 'ETH' : fill.tokenQuote.symbol.toUpperCase();
     const displayAmountQuote = `${amountQuote} ${tokenQuoteSymbol}`;
-
-    const currencyPair: CurrencyPair = getCurrencyPairByTokensSymbol(fill.tokenBase.symbol, fill.tokenQuote.symbol);
-
+    let currencyPair: CurrencyPair;
+    try {
+        currencyPair = getCurrencyPairByTokensSymbol(fill.tokenBase.symbol, fill.tokenQuote.symbol);
+    } catch {
+        return null;
+    }
     const price = parseFloat(fill.price.toString()).toFixed(currencyPair.config.pricePrecision);
 
     return (
@@ -68,45 +81,52 @@ class MarketFills extends React.Component<Props> {
     public render = () => {
         const { marketFills, baseToken, quoteToken, web3State } = this.props;
         let content: React.ReactNode;
-        switch (web3State) {
-            case Web3State.Locked:
-            case Web3State.NotInstalled: {
-                content = <EmptyContent alignAbsoluteCenter={true} text="Connect Wallet to show history" />;
-                break;
-            }
-            case Web3State.Loading: {
+        const defaultBehaviour = () => {
+            if (web3State !== Web3State.Error && (!baseToken || !quoteToken)) {
                 content = <LoadingWrapper minHeight="120px" />;
-                break;
+            } else if (!Object.keys(marketFills).length || !baseToken || !quoteToken) {
+                content = <EmptyContent alignAbsoluteCenter={true} text="There are no trades to show" />;
+            } else if (!marketFills[marketToStringFromTokens(baseToken, quoteToken)]) {
+                content = <EmptyContent alignAbsoluteCenter={true} text="There are no trades to show" />;
+            } else {
+                const market = marketToStringFromTokens(baseToken, quoteToken);
+                const tokenQuoteSymbol = isWeth(quoteToken.symbol) ? 'ETH' : quoteToken.symbol.toUpperCase();
+                const tokenBaseSymbol = isWeth(baseToken.symbol) ? 'ETH' : baseToken.symbol.toUpperCase();
+                content = (
+                    <Table isResponsive={true}>
+                        <THead>
+                            <TR>
+                                <TH>Side</TH>
+                                <TH styles={{ textAlign: 'right' }}>Price ({tokenQuoteSymbol})</TH>
+                                <TH styles={{ textAlign: 'right' }}>Amount ({tokenBaseSymbol})</TH>
+                                <TH styles={{ textAlign: 'right' }}>Total ({tokenQuoteSymbol})</TH>
+                                <TH styles={{ textAlign: 'right' }}>Age</TH>
+                            </TR>
+                        </THead>
+                        <tbody>{marketFills[market].map((marketFill, index) => fillToRow(marketFill, index))}</tbody>
+                    </Table>
+                );
             }
-            default: {
-                if (web3State !== Web3State.Error && (!baseToken || !quoteToken)) {
-                    content = <LoadingWrapper minHeight="120px" />;
-                } else if (!Object.keys(marketFills).length || !baseToken || !quoteToken) {
-                    content = <EmptyContent alignAbsoluteCenter={true} text="There are no trades to show" />;
-                } else if (!marketFills[marketToStringFromTokens(baseToken, quoteToken)]) {
-                    content = <EmptyContent alignAbsoluteCenter={true} text="There are no trades to show" />;
-                } else {
-                    const market = marketToStringFromTokens(baseToken, quoteToken);
-                    const tokenQuoteSymbol = isWeth(quoteToken.symbol) ? 'ETH' : quoteToken.symbol.toUpperCase();
-                    const tokenBaseSymbol = isWeth(baseToken.symbol) ? 'ETH' : baseToken.symbol.toUpperCase();
-                    content = (
-                        <Table isResponsive={true}>
-                            <THead>
-                                <TR>
-                                    <TH>Side</TH>
-                                    <TH styles={{ textAlign: 'right' }}>Price ({tokenQuoteSymbol})</TH>
-                                    <TH styles={{ textAlign: 'right' }}>Amount ({tokenBaseSymbol})</TH>
-                                    <TH styles={{ textAlign: 'right' }}>Total ({tokenQuoteSymbol})</TH>
-                                    <TH styles={{ textAlign: 'right' }}>Age</TH>
-                                </TR>
-                            </THead>
-                            <tbody>
-                                {marketFills[market].map((marketFill, index) => fillToRow(marketFill, index))}
-                            </tbody>
-                        </Table>
-                    );
+        };
+
+        if (USE_RELAYER_MARKET_UPDATES) {
+            defaultBehaviour();
+        } else {
+            switch (web3State) {
+                case Web3State.Locked:
+                case Web3State.NotInstalled: {
+                    content = <EmptyContent alignAbsoluteCenter={true} text="Connect Wallet to show history" />;
+                    break;
                 }
-                break;
+                case Web3State.Loading: {
+                    content = <LoadingWrapper minHeight="120px" />;
+                    break;
+                }
+                default:
+                    {
+                        defaultBehaviour();
+                    }
+                    break;
             }
         }
 

--- a/src/components/erc20/marketplace/order_fills.tsx
+++ b/src/components/erc20/marketplace/order_fills.tsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import TimeAgo from 'react-timeago';
 import styled from 'styled-components';
 
+import { USE_RELAYER_MARKET_UPDATES } from '../../../common/constants';
 import { changeMarket, goToHome } from '../../../store/actions';
 import { getBaseToken, getFills, getQuoteToken, getWeb3State } from '../../../store/selectors';
 import { getCurrencyPairByTokensSymbol } from '../../../util/known_currency_pairs';
@@ -43,9 +44,16 @@ export const ClicableTD = styled(CustomTD)`
 
 const fillToRow = (fill: Fill, index: number, _setMarket: any) => {
     const sideLabel = fill.side === OrderSide.Sell ? 'Sell' : 'Buy';
-    const amountBase = tokenAmountInUnits(fill.amountBase, fill.tokenBase.decimals, fill.tokenBase.displayDecimals);
+    let amountBase;
+    let amountQuote;
+    if (USE_RELAYER_MARKET_UPDATES) {
+        amountBase = fill.amountBase.toFixed(fill.tokenBase.displayDecimals);
+        amountQuote = fill.amountQuote.toFixed(fill.tokenQuote.displayDecimals);
+    } else {
+        amountBase = tokenAmountInUnits(fill.amountBase, fill.tokenBase.decimals, fill.tokenBase.displayDecimals);
+        amountQuote = tokenAmountInUnits(fill.amountQuote, fill.tokenQuote.decimals, fill.tokenQuote.displayDecimals);
+    }
     const displayAmountBase = `${amountBase} ${fill.tokenBase.symbol.toUpperCase()}`;
-    const amountQuote = tokenAmountInUnits(fill.amountQuote, fill.tokenQuote.decimals, fill.tokenQuote.displayDecimals);
     const tokenQuoteSymbol = isWeth(fill.tokenQuote.symbol) ? 'ETH' : fill.tokenQuote.symbol.toUpperCase();
     const tokenBaseSymbol = isWeth(fill.tokenBase.symbol) ? 'ETH' : fill.tokenBase.symbol.toUpperCase();
     const displayAmountQuote = `${amountQuote} ${tokenQuoteSymbol}`;
@@ -53,7 +61,7 @@ const fillToRow = (fill: Fill, index: number, _setMarket: any) => {
     let currencyPair: CurrencyPair;
     try {
         currencyPair = getCurrencyPairByTokensSymbol(fill.tokenBase.symbol, fill.tokenQuote.symbol);
-    } catch {
+    } catch (e) {
         return null;
     }
     const price = parseFloat(fill.price.toString()).toFixed(currencyPair.config.pricePrecision);
@@ -79,51 +87,56 @@ class OrderFills extends React.Component<Props> {
     public render = () => {
         const { fills, baseToken, quoteToken, web3State } = this.props;
         let content: React.ReactNode;
-        switch (web3State) {
-            case Web3State.Locked:
-            case Web3State.NotInstalled: {
-                content = <EmptyContent alignAbsoluteCenter={true} text="Connect Wallet to show history" />;
-                break;
-            }
-            case Web3State.Loading: {
+        const defaultBehaviour = () => {
+            if (web3State !== Web3State.Error && (!baseToken || !quoteToken)) {
                 content = <LoadingWrapper minHeight="120px" />;
-                break;
+            } else if (!fills.length || !baseToken || !quoteToken) {
+                content = <EmptyContent alignAbsoluteCenter={true} text="There are no trades to show" />;
+            } else {
+                const _setMarket: any = (currencyPair: CurrencyPair) => {
+                    this.props.changeMarket(currencyPair);
+                    this.props.goToHome();
+                };
+                content = (
+                    <Table isResponsive={true}>
+                        <THead>
+                            <TR>
+                                <TH>Side</TH>
+                                <TH styles={{ textAlign: 'right' }}>Market</TH>
+                                <TH styles={{ textAlign: 'right' }}>Price</TH>
+                                <TH styles={{ textAlign: 'right' }}>Base</TH>
+                                <TH styles={{ textAlign: 'right' }}>Quote</TH>
+                                <TH styles={{ textAlign: 'right' }}>Age</TH>
+                            </TR>
+                        </THead>
+                        <tbody>{fills.map((fill, index) => fillToRow(fill, index, _setMarket))}</tbody>
+                    </Table>
+                );
             }
-            default: {
-                if (web3State !== Web3State.Error && (!baseToken || !quoteToken)) {
-                    content = <LoadingWrapper minHeight="120px" />;
-                } else if (!fills.length || !baseToken || !quoteToken) {
-                    content = <EmptyContent alignAbsoluteCenter={true} text="There are no trades to show" />;
-                } else {
-                    const _setMarket: any = (currencyPair: CurrencyPair) => {
-                        this.props.changeMarket(currencyPair);
-                        this.props.goToHome();
-                    };
-
-                    content = (
-                        <Table isResponsive={true}>
-                            <THead>
-                                <TR>
-                                    <TH>Side</TH>
-                                    <TH styles={{ textAlign: 'right' }}>Market</TH>
-                                    <TH styles={{ textAlign: 'right' }}>Price</TH>
-                                    <TH styles={{ textAlign: 'right' }}>Base</TH>
-                                    <TH styles={{ textAlign: 'right' }}>Quote</TH>
-                                    <TH styles={{ textAlign: 'right' }}>Age</TH>
-                                </TR>
-                            </THead>
-                            <tbody>{fills.map((fill, index) => fillToRow(fill, index, _setMarket))}</tbody>
-                        </Table>
-                    );
+        };
+        if (USE_RELAYER_MARKET_UPDATES) {
+            defaultBehaviour();
+        } else {
+            switch (web3State) {
+                case Web3State.Locked:
+                case Web3State.NotInstalled: {
+                    content = <EmptyContent alignAbsoluteCenter={true} text="Connect Wallet to show history" />;
+                    break;
                 }
-                break;
+                case Web3State.Loading: {
+                    content = <LoadingWrapper minHeight="120px" />;
+                    break;
+                }
+                default: {
+                    defaultBehaviour();
+                    break;
+                }
             }
-        }
 
-        return <DexTradesList title="Last 0X Mesh Trades">{content}</DexTradesList>;
+            return <DexTradesList title="Last 0X Mesh Trades">{content}</DexTradesList>;
+        }
     };
 }
-
 const mapStateToProps = (state: StoreState): StateProps => {
     return {
         baseToken: getBaseToken(state),

--- a/src/components/erc20/marketplace/order_fills.tsx
+++ b/src/components/erc20/marketplace/order_fills.tsx
@@ -86,7 +86,7 @@ const fillToRow = (fill: Fill, index: number, _setMarket: any) => {
 class OrderFills extends React.Component<Props> {
     public render = () => {
         const { fills, baseToken, quoteToken, web3State } = this.props;
-        let content: React.ReactNode;
+        let content: React.ReactNode = null;
         const defaultBehaviour = () => {
             if (web3State !== Web3State.Error && (!baseToken || !quoteToken)) {
                 content = <LoadingWrapper minHeight="120px" />;
@@ -132,9 +132,8 @@ class OrderFills extends React.Component<Props> {
                     break;
                 }
             }
-
-            return <DexTradesList title="Last 0X Mesh Trades">{content}</DexTradesList>;
         }
+        return <DexTradesList title="Last 0X Mesh Trades">{content}</DexTradesList>;
     };
 }
 const mapStateToProps = (state: StoreState): StateProps => {

--- a/src/config/config.json
+++ b/src/config/config.json
@@ -118,7 +118,7 @@
             "config": {
                 "basePrecision": 0,
                 "pricePrecision": 7,
-                "minAmount": 10000
+                "minAmount": 1
             }
         },
         {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -10,6 +10,7 @@ import configTipBotWhitelistAddresses from './files/settingsAssetsWhitelistAddre
 import configFileIEOProduction from './config-ieo.json';
 import configFileTest from './config-test.json';
 import configFileProduction from './config.json';
+// import configFileProduction from '../config/files/config.json';
 import configTipBot from './settingsAssets.json';
 import configTipBotWhitelistAddresses from './settingsAssetsWhitelistAddresses.json';
 

--- a/src/services/relayer.ts
+++ b/src/services/relayer.ts
@@ -162,6 +162,28 @@ export const getRelayer = (): Relayer => {
     return relayer;
 };
 
+export const getMarketFillsFromRelayer = async (
+    pair: string,
+    page?: number,
+    perPage?: number,
+): Promise<AccountMarketStat[]> => {
+    const headers = new Headers({
+        'content-type': 'application/json',
+    });
+
+    const init: RequestInit = {
+        method: 'GET',
+        headers,
+    };
+    const response = await fetch(`${RELAYER_URL}/markets/${pair}/history`, init);
+    if (response.ok) {
+        return (await response.json()) as AccountMarketStat[];
+    } else {
+        return [];
+    }
+};
+
+
 export const getAccountMarketStatsFromRelayer = async (
     pair: string,
     from: number,

--- a/src/services/relayer.ts
+++ b/src/services/relayer.ts
@@ -2,11 +2,21 @@ import { assetDataUtils, AssetProxyId, BigNumber } from '0x.js';
 import { HttpClient, OrderConfigRequest, OrderConfigResponse, SignedOrder } from '@0x/connect';
 import { RateLimit } from 'async-sema';
 
-import { RELAYER_URL } from '../common/constants';
+import { RELAYER_URL, RELAYER_WS_URL } from '../common/constants';
+import { getLogger } from '../util/logger';
 import { serializeOrder } from '../util/orders';
 import { tokenAmountInUnitsToBigNumber } from '../util/tokens';
-import { AccountMarketStat, MarketData, Token } from '../util/types';
-
+import {
+    AccountMarketStat,
+    MarketData,
+    PaginatedRelayerCollection,
+    RelayerFill,
+    RelayerMarketStats,
+    Token,
+} from '../util/types';
+// tslint:disable-next-line
+const uuidv1 = require('uuid/v1');
+const logger = getLogger('Services::Relayer');
 export class Relayer {
     private readonly _client: HttpClient;
     private readonly _rateLimit: () => Promise<void>;
@@ -164,9 +174,9 @@ export const getRelayer = (): Relayer => {
 
 export const getMarketFillsFromRelayer = async (
     pair: string,
-    page?: number,
-    perPage?: number,
-): Promise<AccountMarketStat[]> => {
+    page: number = 0,
+    perPage: number = 100,
+): Promise<PaginatedRelayerCollection<RelayerFill[]> | null> => {
     const headers = new Headers({
         'content-type': 'application/json',
     });
@@ -175,14 +185,56 @@ export const getMarketFillsFromRelayer = async (
         method: 'GET',
         headers,
     };
-    const response = await fetch(`${RELAYER_URL}/markets/${pair}/history`, init);
+    // Get only last 100 trades
+    const response = await fetch(
+        `${RELAYER_URL}/markets/${pair}/history?page=${page}&perPage=${(page + 1) * perPage}`,
+        init,
+    );
     if (response.ok) {
-        return (await response.json()) as AccountMarketStat[];
+        return (await response.json()) as PaginatedRelayerCollection<RelayerFill[]>;
     } else {
-        return [];
+        return null;
     }
 };
 
+export const getFillsFromRelayer = async (
+    page: number = 0,
+    perPage: number = 100,
+): Promise<PaginatedRelayerCollection<RelayerFill[]> | null> => {
+    const headers = new Headers({
+        'content-type': 'application/json',
+    });
+
+    const init: RequestInit = {
+        method: 'GET',
+        headers,
+    };
+    // Get only last 100 trades
+    const response = await fetch(`${RELAYER_URL}/markets/history?page=${page}&perPage=${(page + 1) * perPage}`, init);
+    if (response.ok) {
+        return (await response.json()) as PaginatedRelayerCollection<RelayerFill[]>;
+    } else {
+        return null;
+    }
+};
+
+export const getMarketStatsFromRelayer = async (pair: string): Promise<RelayerMarketStats | null> => {
+    const headers = new Headers({
+        'content-type': 'application/json',
+    });
+
+    const init: RequestInit = {
+        method: 'GET',
+        headers,
+    };
+    // Get only last 100 trades
+    const response = await fetch(`${RELAYER_URL}/markets/stats/${pair}`, init);
+    if (response.ok) {
+        return (await response.json()) as RelayerMarketStats;
+    } else {
+        return null;
+    }
+};
 
 export const getAccountMarketStatsFromRelayer = async (
     pair: string,
@@ -261,4 +313,46 @@ export const getAllIEOSignedOrders = async (): Promise<SignedOrder[]> => {
     } else {
         return [];
     }
+};
+
+let relayerSocket: WebSocket | null;
+export const getWebsocketRelayerConnection = () => {
+    if (!relayerSocket) {
+        relayerSocket = new WebSocket(RELAYER_WS_URL);
+    }
+    return relayerSocket;
+};
+
+export const startWebsocketMarketsSubscription = (cb_onmessage: any): WebSocket => {
+    const socket = getWebsocketRelayerConnection();
+    const uuid = uuidv1();
+    const requestAll = {
+        type: 'SUBSCRIBE',
+        topic: 'BOOK',
+        market: 'ALL_FILLS_OPTS',
+        requestId: uuid,
+    };
+    socket.onopen = event => {
+        socket.send(JSON.stringify(requestAll));
+    };
+    socket.onerror = event => {
+        logger.error('Socket error. Reconnect will be attempted in 1 second.');
+        setTimeout(() => {
+            relayerSocket = null;
+            startWebsocketMarketsSubscription(cb_onmessage);
+        }, 1000);
+    };
+
+    socket.onclose = event => {
+        logger.error('Socket is closed. Reconnect will be attempted in 1 second.');
+        setTimeout(() => {
+            relayerSocket = null;
+            startWebsocketMarketsSubscription(cb_onmessage);
+        }, 1000);
+    };
+    socket.onmessage = event => {
+        cb_onmessage(event);
+    };
+
+    return socket;
 };

--- a/src/store/market/reducers.ts
+++ b/src/store/market/reducers.ts
@@ -18,6 +18,7 @@ const initialMarketState: MarketState = {
     markets: null,
     ethInUsd: null,
     tokensPrice: null,
+    marketStats: null,
 };
 
 export function market(state: MarketState = initialMarketState, action: RootAction): MarketState {
@@ -48,6 +49,8 @@ export function market(state: MarketState = initialMarketState, action: RootActi
             return state;
         case getType(actions.fetchERC20MarketsError):
             return state;
+        case getType(actions.setMarketStats):
+            return { ...state, marketStats: action.payload };
         default:
             return state;
     }

--- a/src/util/fills.ts
+++ b/src/util/fills.ts
@@ -1,10 +1,10 @@
 import { assetDataUtils, BigNumber, ExchangeFillEventArgs, LogWithDecodedArgs } from '0x.js';
 
-import { KnownTokens } from './known_tokens';
+import { getKnownTokens, KnownTokens } from './known_tokens';
 import { marketToStringFromTokens } from './markets';
 import { getOrderSideFromFillEvent } from './notifications';
 import { getTransactionLink } from './transaction_link';
-import { Fill, Market, OrderSide, Token } from './types';
+import { Fill, Market, OrderSide, RelayerFill, Token } from './types';
 
 export const buildFill = (
     log: LogWithDecodedArgs<ExchangeFillEventArgs>,
@@ -63,4 +63,21 @@ export const getTransactionHashFromFill = (fill: Fill): string => {
 export const getEtherscanUrlForFillTx = (fill: Fill): string => {
     const hash = getTransactionHashFromFill(fill);
     return getTransactionLink(hash);
+};
+
+export const mapRelayerFillToFill = (fill: RelayerFill): Fill => {
+    const known_tokens = getKnownTokens();
+    return {
+        id: fill.id,
+        amountQuote: new BigNumber(fill.filledTokenQuoteAmount),
+        amountBase: new BigNumber(fill.filledTokenBaseAmount),
+        tokenQuote: known_tokens.getTokenByAddress(fill.tokenQuoteAddress),
+        tokenBase: known_tokens.getTokenByAddress(fill.tokenBaseAddress),
+        side: fill.side === 'BUY' ? OrderSide.Buy : OrderSide.Sell,
+        price: fill.price,
+        timestamp: new Date(Number(fill.created_at)),
+        makerAddress: fill.makerAddress,
+        takerAddress: fill.takerAddress,
+        market: fill.pair,
+    };
 };

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -167,6 +167,7 @@ export interface MarketState {
     readonly quoteInUsd?: BigNumber | null;
     readonly markets: Market[] | null;
     readonly tokensPrice: TokenPrice[] | null;
+    readonly marketStats: RelayerMarketStats | null;
 }
 
 export interface StoreState {
@@ -387,8 +388,83 @@ export interface Fill {
     market: string;
 }
 
+export interface RelayerFill {
+    id: string;
+    tradeId: number;
+    order_hash: string;
+    senderAddress: string;
+    makerAddress: string;
+    takerAddress: string;
+    tokenBaseAddress: string;
+    tokenQuoteAddress: string;
+    exchangeAddress: string;
+    feeRecipientAddress: string;
+    makerFee: string;
+    takerFee: string;
+    filledTokenBaseAmount: string;
+    filledTokenQuoteAmount: string;
+    price: string;
+    signature: string;
+    from: string;
+    created_at: number;
+    side: 'BUY' | 'SELL';
+    pair: string;
+    blockNumber: number;
+}
+
+export interface PaginatedRelayerCollection<T> {
+    total: number;
+    page: number;
+    perPage: number;
+    records: T;
+}
+
+export interface RelayerMarketStats {
+    base: string;
+    quote: string;
+    pair: string;
+    volume_24: number;
+    total_orders: number;
+    price_max_24: number;
+    open_price: number;
+    close_price: number;
+    price_min_24: number;
+    last_price: number;
+    last_price_change: number;
+    last_price_usd: string;
+    utc_date: string;
+    utc_timestamp: number;
+    updated_at: number;
+    resolution: 'D';
+}
+
 export interface MarketFill {
     [market: string]: Fill[];
+}
+
+export interface OrderFilledMessage {
+    action: 'FILL';
+    event: {
+        id: string;
+        baseTokenAddress: string;
+        quoteTokenAddress: string;
+        transactionHash: string;
+        type: 'SELL' | 'BUY';
+        blockNumber: number;
+        makerAddress: string;
+        takerAddress: string;
+        feeRecipientAddress: string;
+        makerFeePaid: string;
+        takerFeePaid: string;
+        filledBaseTokenAmount: string;
+        filledQuoteTokenAmount: string;
+        orderHash: string;
+        timestamp: number;
+        outlier: boolean;
+        price: string;
+        pair: string;
+    };
+    requestId: string;
 }
 
 export interface MarketData {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15336,6 +15336,11 @@ uuid@^3.0.1, uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
+uuid@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
+  integrity sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==
+
 v8flags@^3.0.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/v8flags/-/v8flags-3.1.3.tgz#fc9dc23521ca20c5433f81cc4eb9b3033bb105d8"


### PR DESCRIPTION
At the moment users to saw trades from 0x mesh and the current market they need to log in with an erc-20  wallet because the fills are fetched on-chain using decentralized RPC requests. This can cause the sense that in the dex is not being happened any trade when the user not log in the wallet. 

This happens all the time when user first opens the dex and to have a better UX dex must show the true activity to newcomers.

This option could be enabled and disabled using an environment variable.

Dex being able to work without a server is also possible and in sometimes desirable when you want a purely decentralized dex, however, you will face the shortcomings enumerated above.



