### PR TITLE
Feature/market maker

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,11 +3,11 @@
     "version": "0.3.0",
     "private": true,
     "dependencies": {
-        "@0x/asset-swapper": "^4.2.0",
+        "@0x/asset-swapper": "^4.4.0",
         "@0x/connect": "^6.0.6",
         "@0x/contract-wrappers": "^13.6.3",
         "@0x/order-utils": "^10.1.0",
-        "@0x/orderbook": "^2.2.1",
+        "@0x/orderbook": "^2.2.5",
         "@0x/subproviders": "^6.0.8",
         "@0x/utils": "^5.4.0",
         "@0x/web3-wrapper": "^7.0.7",

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -10,6 +10,7 @@ export const LAUNCHPAD_APP_BASE_PATH = '/launchpad';
 export const MARGIN_APP_BASE_PATH = '/margin';
 export const INSTANT_APP_BASE_PATH = '/instant';
 export const FIAT_RAMP_APP_BASE_PATH = '/fiat-onramp';
+export const MARKET_MAKER_APP_BASE_PATH = `${ERC20_APP_BASE_PATH}/market-maker`;
 
 export const USE_RELAYER_MARKET_UPDATES = process.env.REACT_APP_USE_RELAYER_MARKET_UPDATES === 'true' ? true : false;
 
@@ -180,15 +181,48 @@ export const ONE_SECOND_MS = 1000;
 
 export const QUOTE_ORDER_EXPIRATION_BUFFER_MS = ONE_SECOND_MS * 30; // Ignore orders that expire in 30 seconds
 
+const EXCLUDED_SOURCES = (() => {
+    switch (CHAIN_ID) {
+        case ChainId.Mainnet:
+            return [];
+        case ChainId.Kovan:
+            return [ERC20BridgeSource.Kyber];
+        default:
+            return [ERC20BridgeSource.Eth2Dai, ERC20BridgeSource.Kyber, ERC20BridgeSource.Uniswap];
+    }
+})();
+
+/*const gasSchedule: { [key in ERC20BridgeSource]: number } = {
+    [ERC20BridgeSource.Native]: 1.5e5,
+    [ERC20BridgeSource.Uniswap]: 3e5,
+   // [ERC20BridgeSource.LiquidityProvider]: 3e5,
+    [ERC20BridgeSource.Eth2Dai]: 5.5e5,
+    [ERC20BridgeSource.Kyber]: 8e5,
+    [ERC20BridgeSource.CurveUsdcDai]: 9e5,
+    [ERC20BridgeSource.CurveUsdcDaiUsdt]: 9e5,
+    [ERC20BridgeSource.CurveUsdcDaiUsdtTusd]: 10e5,
+    [ERC20BridgeSource.CurveUsdcDaiUsdtBusd]: 10e5,
+};*/
+
+/*const feeSchedule: { [key in ERC20BridgeSource]: BigNumber } = Object.assign(
+    {},
+    ...(Object.keys(gasSchedule) as ERC20BridgeSource[]).map(k => ({
+        [k]: new BigNumber(gasSchedule[k] + 1.5e5),
+    })),
+);*/
+
+const DEFAULT_QUOTE_SLIPPAGE_PERCENTAGE = 0.03; // 3% Slippage
+// const DEFAULT_FALLBACK_SLIPPAGE_PERCENTAGE = 0.015; // 1.5% Slippage in a fallback route
+
 export const ASSET_SWAPPER_MARKET_ORDERS_OPTS: Partial<SwapQuoteRequestOpts> = {
     noConflicts: true,
-    excludedSources:
-        CHAIN_ID === ChainId.Mainnet
-            ? []
-            : [ERC20BridgeSource.Eth2Dai, ERC20BridgeSource.Kyber, ERC20BridgeSource.Uniswap],
-    numSamples: 10,
-    runLimit: 4096,
-    bridgeSlippage: 0.0005,
-    dustFractionThreshold: 0.0025,
+    excludedSources: EXCLUDED_SOURCES,
+    bridgeSlippage: DEFAULT_QUOTE_SLIPPAGE_PERCENTAGE,
+    // maxFallbackSlippage: DEFAULT_FALLBACK_SLIPPAGE_PERCENTAGE,
+    numSamples: 13,
     sampleDistributionBase: 1.05,
+    runLimit: 4096,
+    dustFractionThreshold: 0.0025,
+    // feeSchedule,
+    // gasSchedule,
 };

--- a/src/common/markets.ts
+++ b/src/common/markets.ts
@@ -26,7 +26,7 @@ export const getAvailableMarkets = (): CurrencyPair[] => {
     return availableMarkets;
 };
 
-export const addAvailableMarket = (token: Token): CurrencyPair | null => {
+export const addWethAvailableMarket = (token: Token): CurrencyPair | null => {
     const availableMarketsData = getAvailableMarkets();
     const known_tokens = getKnownTokens();
     const wethToken = known_tokens.getWethToken();

--- a/src/components/common/final_form/sketch_input.tsx
+++ b/src/components/common/final_form/sketch_input.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { ColorResult, MaterialPicker } from 'react-color';
 import { FieldRenderProps } from 'react-final-form';
 import styled from 'styled-components';

--- a/src/components/common/steps_modal/sign_order_step.tsx
+++ b/src/components/common/steps_modal/sign_order_step.tsx
@@ -47,7 +47,7 @@ class SignOrderStep extends React.Component<Props, State> {
 
         const isBuy = step.side === OrderSide.Buy;
         const title = 'Order setup';
-        const confirmCaption = `Confirm signature on ${wallet} to submit order to the book.`;
+        const confirmCaption = `Confirm signature on ${wallet} to submit ${isBuy ? 'buy' : 'sell'} order  to the book.`;
         const loadingCaption = 'Submitting order.';
         const doneCaption = `${isBuy ? 'Buy' : 'Sell'} order for ${tokenSymbolToDisplayString(
             step.token.symbol,

--- a/src/components/erc20/account/mobile_wallet_connection_content.tsx
+++ b/src/components/erc20/account/mobile_wallet_connection_content.tsx
@@ -7,7 +7,6 @@ import styled from 'styled-components';
 import {
     goToHome,
     goToHomeLaunchpad,
-    goToHomeMarginLend,
     goToHomeMarketTrade,
     goToWallet,
     logoutWallet,
@@ -80,10 +79,10 @@ export const MobileWalletConnectionContent = () => {
         dispatch(openSideBar(false));
     };
 
-    const onGoToMarginLend = () => {
+    /*const onGoToMarginLend = () => {
         dispatch(goToHomeMarginLend());
         dispatch(openSideBar(false));
-    };
+    };*/
 
     const onGoToWallet = () => {
         dispatch(goToWallet());

--- a/src/components/erc20/account/wallet_connection_content.tsx
+++ b/src/components/erc20/account/wallet_connection_content.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 import {
     goToHomeLaunchpad,
     goToHomeMarginLend,
+    goToHomeMarketMaker,
     goToHomeMarketTrade,
     goToWallet,
     logoutWallet,
@@ -30,6 +31,7 @@ interface DispatchProps {
     onGoToHomeLaunchpad: () => any;
     onGoToHomeMarginLend: () => any;
     onGoToHomeMarketTrade: () => any;
+    onGoToHomeMarketMaker: () => any;
 }
 
 type Props = StateProps & OwnProps & DispatchProps;
@@ -48,6 +50,7 @@ class WalletConnectionContent extends React.PureComponent<Props> {
             onGoToHomeMarginLend,
             onGoToHomeMarketTrade,
             onGoToWallet,
+            onGoToHomeMarketMaker,
             ...restProps
         } = this.props;
         const ethAccountText = ethAccount ? `${truncateAddress(ethAccount)}` : 'Not connected';
@@ -76,6 +79,7 @@ class WalletConnectionContent extends React.PureComponent<Props> {
                 <DropdownTextItem onClick={connectToExplorer} text="Track DEX volume" />
                 <DropdownTextItem onClick={openFabrx} text="Set Alerts" />
                 <DropdownTextItem onClick={onGoToHomeLaunchpad} text="Launchpad" />
+                <DropdownTextItem onClick={onGoToHomeMarketMaker} text="Market Maker" />
                 {/* <DropdownTextItem onClick={onGoToHomeMarginLend} text="Lend" />*/}
                 <DropdownTextItem onClick={onLogoutWallet} text="Logout Wallet" />
             </DropdownItems>
@@ -104,6 +108,7 @@ const mapDispatchToProps = (dispatch: any): DispatchProps => {
         onGoToHomeLaunchpad: () => dispatch(goToHomeLaunchpad()),
         onGoToHomeMarginLend: () => dispatch(goToHomeMarginLend()),
         onGoToHomeMarketTrade: () => dispatch(goToHomeMarketTrade()),
+        onGoToHomeMarketMaker: () => dispatch(goToHomeMarketMaker()),
     };
 };
 

--- a/src/components/erc20/common/0xinstant.tsx
+++ b/src/components/erc20/common/0xinstant.tsx
@@ -87,6 +87,7 @@ export const ZeroXInstantComponent = (props: Props) => {
         const isBot = query.get('isBot');
         const makerAddresses = query.get('addresses');
         const makerAddress = query.get('makerAddress');
+
         // const affiliate = query.get('affiliate');
         //  const affiliatePercentage = query.get('affiliatePercentage');
         let additionalAssetMetaDataMap = {};
@@ -149,7 +150,6 @@ export const ZeroXInstantComponent = (props: Props) => {
                 const wethToken = knownTokens.getWethToken();
 
                 orderSource = await getUserIEOSignedOrders(baseToken.owners[0].toLowerCase(), baseToken, wethToken);
-
                 if (!orderSource || orderSource.length === 0) {
                     orderSource = undefined;
                 }

--- a/src/components/erc20/common/markets_dropdown_stats.tsx
+++ b/src/components/erc20/common/markets_dropdown_stats.tsx
@@ -3,9 +3,16 @@ import React, { HTMLAttributes } from 'react';
 import { connect } from 'react-redux';
 import styled from 'styled-components';
 
+import { MARKET_MAKER_APP_BASE_PATH } from '../../../common/constants';
 import { marketFilters } from '../../../common/markets';
 import { changeMarket, goToHome } from '../../../store/actions';
-import { getBaseToken, getCurrencyPair, getMarkets, getMarketsStats } from '../../../store/selectors';
+import {
+    getBaseToken,
+    getCurrencyPair,
+    getCurrentRoutePath,
+    getMarkets,
+    getMarketsStats,
+} from '../../../store/selectors';
 import { themeBreakPoints, themeDimensions } from '../../../themes/commons';
 import { getKnownTokens } from '../../../util/known_tokens';
 import { filterMarketsByString, filterMarketsByTokenSymbol, marketToString } from '../../../util/markets';
@@ -32,6 +39,7 @@ interface PropsToken {
     currencyPair: CurrencyPair;
     markets: Market[] | null;
     marketsStats: RelayerMarketStats[] | null | undefined;
+    currentRoute: string;
 }
 interface OwnProps {
     windowWidth: number;
@@ -430,7 +438,11 @@ class MarketsDropdownStats extends React.Component<Props, State> {
 
     private readonly _setSelectedMarket: any = (currencyPair: CurrencyPair) => {
         this.props.changeMarket(currencyPair);
-        this.props.goToHome();
+
+        if (!this.props.currentRoute.includes(MARKET_MAKER_APP_BASE_PATH)) {
+            this.props.goToHome();
+        }
+
         if (this._dropdown.current) {
             this._dropdown.current.closeDropdown();
         }
@@ -451,6 +463,7 @@ const mapStateToProps = (state: StoreState): PropsToken => {
         currencyPair: getCurrencyPair(state),
         markets: getMarkets(state),
         marketsStats: getMarketsStats(state),
+        currentRoute: getCurrentRoutePath(state),
     };
 };
 

--- a/src/components/erc20/erc20_app.tsx
+++ b/src/components/erc20/erc20_app.tsx
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 import { Route, Switch } from 'react-router';
 import { ThemeProvider } from 'styled-components';
 
-import { ERC20_APP_BASE_PATH } from '../../common/constants';
+import { ERC20_APP_BASE_PATH, MARKET_MAKER_APP_BASE_PATH } from '../../common/constants';
 import { AdBlockDetector } from '../../components/common/adblock_detector';
 import { GeneralLayoutContainer } from '../../components/general_layout';
 import { getERC20Theme } from '../../store/selectors';
@@ -21,6 +21,7 @@ const WizardPage = lazy(() => import('./pages/wizard'));
 const JoinAsMakerPage = lazy(() => import('./pages/join_as_maker'));
 const TokenListingPage = lazy(() => import('./pages/listing'));
 const UserWizardPage = lazy(() => import('./pages/user_wizard'));
+const MarketMakerPage = lazy(() => import('./pages/market_maker'));
 
 const Erc20App = () => {
     const themeColor = useSelector(getERC20Theme);
@@ -35,6 +36,7 @@ const Erc20App = () => {
                         <Route exact={true} path={`${ERC20_APP_BASE_PATH}/join-as-maker`} component={JoinAsMakerPage} />
                         <Route exact={true} path={`${ERC20_APP_BASE_PATH}/listed-tokens`} component={TokensListPage} />
                         <Route exact={true} path={`${ERC20_APP_BASE_PATH}/dex-wizard`} component={WizardPage} />
+                        <Route exact={true} path={MARKET_MAKER_APP_BASE_PATH} component={MarketMakerPage} />
                         <Route
                             exact={true}
                             path={`${ERC20_APP_BASE_PATH}/user-dex-wizard`}

--- a/src/components/erc20/ieo_desk/ieo_order.tsx
+++ b/src/components/erc20/ieo_desk/ieo_order.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import styled from 'styled-components';
 
-import { addAvailableMarket } from '../../../common/markets';
+import { addWethAvailableMarket } from '../../../common/markets';
 import { fetchBaseTokenIEO, initWallet, setCurrencyPair, startBuySellLimitIEOSteps } from '../../../store/actions';
 import { fetchTakerAndMakerFeeIEO } from '../../../store/relayer/actions';
 import {
@@ -232,7 +232,7 @@ class IEOOrder extends React.Component<Props, State> {
                 token = await known_tokens.addTokenByAddress(tokenName, makerAddress);
                 if (token) {
                     await this.props.onFetchBaseTokenIEO(token);
-                    const market = addAvailableMarket(token);
+                    const market = addWethAvailableMarket(token);
                     if (market) {
                         this.props.onAddCurrencyPair(market);
                     }
@@ -288,7 +288,7 @@ class IEOOrder extends React.Component<Props, State> {
 
                     if (token) {
                         await this.props.onFetchBaseTokenIEO(token);
-                        const market = addAvailableMarket(token);
+                        const market = addWethAvailableMarket(token);
                         if (market) {
                             this.props.onAddCurrencyPair(market);
                         }

--- a/src/components/erc20/marketplace/market_maker.tsx
+++ b/src/components/erc20/marketplace/market_maker.tsx
@@ -1,0 +1,495 @@
+import { MarketBuySwapQuote, MarketSellSwapQuote } from '@0x/asset-swapper';
+import { BigNumber } from '@0x/utils';
+import React, { useEffect, useState } from 'react';
+import { connect, useDispatch, useSelector } from 'react-redux';
+import { useLocation } from 'react-router';
+import styled from 'styled-components';
+
+import { ZERO } from '../../../common/constants';
+import { calculateSwapQuote, setSwapBaseToken, startSwapMarketSteps } from '../../../store/actions';
+import {
+    getCurrencyPair,
+    getOrderPriceSelected,
+    getSwapBaseToken,
+    getSwapBaseTokenBalance,
+    getSwapQuote,
+    getSwapQuoteState,
+    getSwapQuoteToken,
+    getSwapQuoteTokenBalance,
+    getTotalEthBalance,
+    getWeb3State,
+} from '../../../store/selectors';
+import { themeDimensions } from '../../../themes/commons';
+import { getKnownTokens, isWeth } from '../../../util/known_tokens';
+import { formatTokenSymbol, tokenAmountInUnits, unitsInTokenAmount } from '../../../util/tokens';
+import {
+    ButtonIcons,
+    ButtonVariant,
+    CurrencyPair,
+    OrderSide,
+    StoreState,
+    SwapQuoteState,
+    TokenBalance,
+    Web3State,
+} from '../../../util/types';
+import { CalculateSwapQuoteParams } from '../../../util/types/swap';
+import { BigNumberInput } from '../../common/big_number_input';
+import { Button } from '../../common/button';
+import { CardBase } from '../../common/card_base';
+import { ErrorCard, FontSize } from '../../common/error_card';
+import { useDebounce } from '../../common/hooks/debounce_hook';
+import { Web3StateButton } from '../../common/web3StateButton';
+
+import { MarketTradeDetailsContainer } from './market_trade_details';
+import { getAssetSwapper } from '../../../services/swap';
+
+interface StateProps {
+    web3State: Web3State;
+    currencyPair: CurrencyPair;
+    orderPriceSelected: BigNumber | null;
+    baseTokenBalance: TokenBalance | null;
+    quoteTokenBalance: TokenBalance | null;
+    totalEthBalance: BigNumber;
+}
+
+interface DispatchProps {
+    onSubmitSwapMarketOrder: (
+        amount: BigNumber,
+        side: OrderSide,
+        quote: MarketBuySwapQuote | MarketSellSwapQuote,
+    ) => Promise<any>;
+}
+
+type Props = StateProps & DispatchProps;
+
+const BuySellWrapper = styled(CardBase)`
+    margin-bottom: ${themeDimensions.verticalSeparationSm};
+`;
+
+const Content = styled.div`
+    display: flex;
+    flex-direction: column;
+    padding: 20px;
+`;
+
+const TabsContainer = styled.div`
+    align-items: center;
+    display: flex;
+    justify-content: space-between;
+`;
+
+const TabButton = styled.div<{ isSelected: boolean; side: OrderSide }>`
+    align-items: center;
+    background-color: ${props =>
+        props.isSelected ? 'transparent' : props.theme.componentsTheme.inactiveTabBackgroundColor};
+    border-bottom-color: ${props => (props.isSelected ? 'transparent' : props.theme.componentsTheme.cardBorderColor)};
+    border-bottom-style: solid;
+    border-bottom-width: 1px;
+    border-right-color: ${props => (props.isSelected ? props.theme.componentsTheme.cardBorderColor : 'transparent')};
+    border-right-style: solid;
+    border-right-width: 1px;
+    color: ${props =>
+        props.isSelected
+            ? props.side === OrderSide.Buy
+                ? props.theme.componentsTheme.green
+                : props.theme.componentsTheme.red
+            : props.theme.componentsTheme.textLight};
+    cursor: ${props => (props.isSelected ? 'default' : 'pointer')};
+    display: flex;
+    font-weight: 600;
+    height: 47px;
+    justify-content: center;
+    width: 50%;
+
+    &:first-child {
+        border-top-left-radius: ${themeDimensions.borderRadius};
+    }
+
+    &:last-child {
+        border-left-color: ${props => (props.isSelected ? props.theme.componentsTheme.cardBorderColor : 'transparent')};
+        border-left-style: solid;
+        border-left-width: 1px;
+        border-right: none;
+        border-top-right-radius: ${themeDimensions.borderRadius};
+    }
+`;
+
+const LabelContainer = styled.div`
+    align-items: flex-end;
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 10px;
+`;
+
+const LabelAvailableContainer = styled.div`
+    align-items: flex-end;
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 5px;
+`;
+
+const Label = styled.label<{ color?: string }>`
+    color: ${props => props.color || props.theme.componentsTheme.textColorCommon};
+    font-size: 14px;
+    font-weight: 500;
+    line-height: normal;
+    margin: 0;
+`;
+
+const LabelAvaible = styled.label<{ color?: string }>`
+    color: ${props => props.color || props.theme.componentsTheme.textColorCommon};
+    font-size: 12px;
+    font-weight: normal;
+    line-height: normal;
+    margin: 0;
+`;
+
+const FieldAmountContainer = styled.div`
+    height: ${themeDimensions.fieldHeight};
+    margin-bottom: 5px;
+    position: relative;
+`;
+
+const BigInputNumberStyled = styled<any>(BigNumberInput)`
+    background-color: ${props => props.theme.componentsTheme.textInputBackgroundColor};
+    border-radius: ${themeDimensions.borderRadius};
+    border: 1px solid ${props => props.theme.componentsTheme.textInputBorderColor};
+    color: ${props => props.theme.componentsTheme.textInputTextColor};
+    font-feature-settings: 'tnum' 1;
+    font-size: 16px;
+    height: 100%;
+    padding-left: 14px;
+    padding-right: 60px;
+    position: absolute;
+    width: 100%;
+    z-index: 1;
+`;
+
+const TokenContainer = styled.div`
+    display: flex;
+    position: absolute;
+    right: 14px;
+    top: 50%;
+    transform: translateY(-50%);
+    z-index: 12;
+`;
+
+const TokenText = styled.span`
+    color: ${props => props.theme.componentsTheme.textInputTextColor};
+    font-size: 14px;
+    font-weight: normal;
+    line-height: 21px;
+    text-align: right;
+`;
+
+const BigInputNumberTokenLabel = (props: { tokenSymbol: string }) => (
+    <TokenContainer>
+        <TokenText>{formatTokenSymbol(props.tokenSymbol)}</TokenText>
+    </TokenContainer>
+);
+
+const TIMEOUT_BTN_ERROR = 2000;
+const TIMEOUT_CARD_ERROR = 4000;
+
+// A custom hook that builds on useLocation to parse
+// the query string for you.
+const useQuery = () => {
+    return new URLSearchParams(useLocation().search);
+};
+
+const MarketMaker = (props: Props) => {
+    const [swapQuoteState, setSwapQuoteState] = useState(SwapQuoteState.NotLoaded);
+    const [buyQuote, setBuyQuote] = useState<MarketBuySwapQuote>();
+    const [sellQuote, setSellQuote] = useState<MarketSellSwapQuote>();
+    const [errorState, setErrorState] = useState<{ btnMsg: null | string; cardMsg: null | string }>({
+        btnMsg: null,
+        cardMsg: null,
+    });
+    const [priceState, setPriceState] = useState(new BigNumber(0));
+    const [makerAmountState, setMakerAmountState] = useState(new BigNumber(0));
+    const { web3State, quoteTokenBalance, baseTokenBalance, totalEthBalance } = props;
+    const swapQuote = useSelector(getSwapQuote);
+    const quoteToken = useSelector(getSwapQuoteToken);
+    const baseToken = useSelector(getSwapBaseToken);
+    const dispatch = useDispatch();
+    const query = useQuery();
+    const queryToken = query.get('token');
+    const decimals = baseToken.decimals;
+    const known_tokens = getKnownTokens();
+    useEffect(() => {
+        const fetchToken = async () => {
+            if (!queryToken) {
+                return;
+            }
+            if (
+                queryToken.toLowerCase() === baseToken.symbol.toLowerCase() ||
+                queryToken.toLowerCase() === baseToken.address.toLowerCase()
+            ) {
+                return;
+            }
+            const t = await known_tokens.findTokenOrFetchIt(queryToken);
+            if (t) {
+                if (t === baseToken) {
+                    return;
+                } else {
+                    dispatch(setSwapBaseToken(t));
+                }
+            }
+        };
+        // tslint:disable-next-line:no-floating-promises
+        fetchToken();
+    }, [queryToken, baseToken]);
+
+    const stepAmount = new BigNumber(1).div(new BigNumber(10).pow(8));
+    const stepAmountUnits = unitsInTokenAmount(String(stepAmount), decimals);
+    const amount = makerAmountState;
+    const isMakerAmountEmpty = amount === null || amount.isZero();
+    let isMaxAmount = false;
+  /*  if (swapQuote && quoteTokenBalance && baseTokenBalance) {
+        isMaxAmount = isSell
+            ? makerAmountState.isGreaterThan(baseTokenBalance.balance)
+            : swapQuote.bestCaseQuoteInfo.takerAssetAmount.isGreaterThan(
+                  isWeth(quoteToken.symbol) ? totalEthBalance : quoteTokenBalance.balance,
+              );
+    }*/
+
+    const isOrderTypeMarketIsEmpty = isMakerAmountEmpty || isMaxAmount;
+    const baseSymbol = formatTokenSymbol(baseToken.symbol);
+
+    const _reset = () => {
+        setMakerAmountState(new BigNumber(0));
+        setPriceState(new BigNumber(0));
+    };
+    const onCalculateSwapQuote = async () => {
+        // We are fetching the price here
+        const buyParams: CalculateSwapQuoteParams = {
+            buyTokenAddress:  baseToken.address,
+            sellTokenAddress:  quoteToken.address,
+            buyAmount:  new BigNumber(1),
+            sellAmount:  undefined,
+            from: undefined,
+            isETHSell: false,
+        };
+        const sellParams: CalculateSwapQuoteParams = {
+            buyTokenAddress: quoteToken.address ,
+            sellTokenAddress:  baseToken.address ,
+            buyAmount:  undefined ,
+            sellAmount: new BigNumber(1),
+            from: undefined,
+            isETHSell: isWeth(quoteToken.symbol),
+        };
+        if (web3State !== Web3State.Done) {
+            return;
+        }
+        
+        const assetSwapper = await getAssetSwapper();
+        const buyQuote = await assetSwapper.getSwapQuoteAsync(buyParams) as MarketBuySwapQuote;
+        setBuyQuote(buyQuote);
+        const sellQuote = await assetSwapper.getSwapQuoteAsync(sellParams) as MarketSellSwapQuote;
+        setSellQuote(sellQuote);
+    };
+
+    const debouncedAmount = useDebounce(makerAmountState, 500);
+    useEffect(() => {
+        if (swapQuoteState === SwapQuoteState.Error) {
+            setErrorState({
+                cardMsg: 'Error fetching quote',
+                btnMsg: 'Try again',
+            });
+            setTimeout(() => {
+                setErrorState({
+                    ...errorState,
+                    btnMsg: null,
+                });
+            }, TIMEOUT_BTN_ERROR);
+
+            setTimeout(() => {
+                setErrorState({
+                    ...errorState,
+                    cardMsg: null,
+                });
+            }, TIMEOUT_CARD_ERROR);
+        } else {
+            if (errorState.cardMsg !== null) {
+                setErrorState({
+                    cardMsg: null,
+                    btnMsg: null,
+                });
+            }
+        }
+    }, [swapQuoteState]);
+
+    useEffect(() => {
+        if (debouncedAmount) {
+            onCalculateSwapQuote();
+        }
+    }, [debouncedAmount]);
+
+    useEffect(() => {
+        if (makerAmountState.isGreaterThan(0)) {
+            onCalculateSwapQuote();
+        }
+    }, [baseToken]);
+
+
+    const onSubmit = async () => {
+        const makerAmount = makerAmountState;
+
+        if (!swapQuote) {
+            return;
+        }
+
+        try {
+         //   await props.onSubmitSwapMarketOrder(makerAmount, orderSide, swapQuote);
+        } catch (error) {
+            setErrorState({
+                btnMsg: 'Error',
+                cardMsg: error.message,
+            });
+            setTimeout(() => {
+                setErrorState({
+                    ...errorState,
+                    btnMsg: null,
+                });
+            }, TIMEOUT_BTN_ERROR);
+
+            setTimeout(() => {
+                setErrorState({
+                    ...errorState,
+                    cardMsg: null,
+                });
+            }, TIMEOUT_CARD_ERROR);
+        }
+
+        _reset();
+    };
+    const onUpdateMakerAmount = (newValue: BigNumber) => {
+        setMakerAmountState(newValue);
+    };
+
+    const getAmountAvailableLabel = (isBase: boolean) => {
+        if (isBase) {
+            if (baseTokenBalance) {
+                const tokenBalanceAmount = isWeth(baseTokenBalance.token.symbol)
+                    ? totalEthBalance
+                    : baseTokenBalance.balance;
+                const baseBalanceString = tokenAmountInUnits(
+                    tokenBalanceAmount,
+                    baseTokenBalance.token.decimals,
+                    baseTokenBalance.token.displayDecimals,
+                );
+                const symbol = formatTokenSymbol(baseTokenBalance.token.symbol);
+                return `Balance: ${baseBalanceString}  ${symbol}`;
+            } else {
+                return null;
+            }
+        } else {
+            if (quoteTokenBalance) {
+                const tokenBalanceAmount = isWeth(quoteTokenBalance.token.symbol)
+                    ? totalEthBalance
+                    : quoteTokenBalance.balance;
+                const quoteBalanceString = tokenAmountInUnits(
+                    tokenBalanceAmount,
+                    quoteTokenBalance.token.decimals,
+                    quoteTokenBalance.token.displayDecimals,
+                );
+                const symbol = formatTokenSymbol(quoteTokenBalance.token.symbol);
+                return `Balance: ${quoteBalanceString}  ${symbol}`;
+            } else {
+                return null;
+            }
+        }
+    };
+    const isListed = baseToken ? baseToken.listed : true;
+    const msg = 'Token inserted by User. Please proceed with caution and do your own research!';
+    return (
+        <>
+            {!isListed && <ErrorCard fontSize={FontSize.Large} text={msg} />}
+            <BuySellWrapper>
+                <Content>
+                    <LabelContainer>
+                        <Label>Insert Amount</Label>
+                    </LabelContainer>
+                    <FieldAmountContainer>
+                        <BigInputNumberStyled
+                            decimals={decimals}
+                            min={ZERO}
+                            onChange={onUpdateMakerAmount}
+                            value={amount}
+                            step={stepAmountUnits}
+                            placeholder={new BigNumber(0).toString()}
+                            valueFixedDecimals={8}
+                        />
+                        <BigInputNumberTokenLabel tokenSymbol={baseToken.symbol} />
+                    </FieldAmountContainer>
+                    <Web3StateButton />
+
+                    <LabelAvailableContainer>
+                        <LabelAvaible>{getAmountAvailableLabel(true)}</LabelAvaible>
+                        <LabelAvaible>{getAmountAvailableLabel(false)}</LabelAvaible>
+                    </LabelAvailableContainer>
+                    <MarketTradeDetailsContainer
+                        orderSide={tabState}
+                        tokenAmount={amount}
+                        tokenPrice={priceState}
+                        baseToken={baseToken}
+                        quoteToken={quoteToken}
+                        quote={swapQuote}
+                        buyQuote={buyQuote}
+                        sellQuote={sellQuote}
+                    />
+                    <Button
+                        disabled={web3State !== Web3State.Done || isOrderTypeMarketIsEmpty}
+                        icon={errorState.btnMsg ? ButtonIcons.Warning : undefined}
+                        onClick={onSubmit}
+                        variant={ButtonVariant.Buy}
+                    >
+                       Place Buy Order
+                    </Button>
+                    <Button
+                        disabled={web3State !== Web3State.Done || isOrderTypeMarketIsEmpty}
+                        icon={errorState.btnMsg ? ButtonIcons.Warning : undefined}
+                        onClick={onSubmit}
+                        variant={ButtonVariant.Sell}
+                    >
+                        Place Sell Order
+                    </Button>
+                    <Button
+                        disabled={web3State !== Web3State.Done || isOrderTypeMarketIsEmpty}
+                        icon={errorState.btnMsg ? ButtonIcons.Warning : undefined}
+                        onClick={onSubmit}
+                        variant={ButtonVariant.Primary}
+                    >
+                      Place Buy and Sell Order
+                    </Button>
+                </Content>
+            </BuySellWrapper>
+            {errorState.cardMsg ? <ErrorCard fontSize={FontSize.Large} text={errorState.cardMsg} /> : null}
+        </>
+    );
+};
+
+const mapStateToProps = (state: StoreState): StateProps => {
+    return {
+        web3State: getWeb3State(state),
+        currencyPair: getCurrencyPair(state),
+        orderPriceSelected: getOrderPriceSelected(state),
+        quoteTokenBalance: getSwapQuoteTokenBalance(state),
+        baseTokenBalance: getSwapBaseTokenBalance(state),
+        totalEthBalance: getTotalEthBalance(state),
+    };
+};
+
+const mapDispatchToProps = (dispatch: any): DispatchProps => {
+    return {
+        onSubmitSwapMarketOrder: (
+            amount: BigNumber,
+            side: OrderSide,
+            quote: MarketBuySwapQuote | MarketSellSwapQuote,
+        ) => dispatch(startSwapMarketSteps(amount, side, quote)),
+    };
+};
+
+const MarketMakerContainer = connect(mapStateToProps, mapDispatchToProps)(MarketMaker);
+
+export { MarketMaker, MarketMakerContainer };

--- a/src/components/erc20/marketplace/market_maker_details.tsx
+++ b/src/components/erc20/marketplace/market_maker_details.tsx
@@ -1,0 +1,365 @@
+import { MarketBuySwapQuote, MarketSellSwapQuote } from '@0x/asset-swapper';
+import { BigNumber, NULL_BYTES } from '@0x/utils';
+import React from 'react';
+import { connect } from 'react-redux';
+import styled, { keyframes } from 'styled-components';
+
+import { ZERO } from '../../../common/constants';
+import { fetchTakerAndMakerFee } from '../../../store/relayer/actions';
+import { getQuoteInUsd, getSwapQuoteState, getTokensPrice, getWeb3State } from '../../../store/selectors';
+import { formatTokenSymbol, tokenAmountInUnits } from '../../../util/tokens';
+import { OrderFeeData, OrderSide, StoreState, SwapQuoteState, Token, TokenPrice, Web3State } from '../../../util/types';
+import { Tooltip } from '../../common/tooltip';
+
+const Row = styled.div`
+    align-items: center;
+    border-top: dashed 1px ${props => props.theme.componentsTheme.borderColor};
+    display: flex;
+    justify-content: space-between;
+    padding: 12px 0;
+    position: relative;
+    z-index: 1;
+
+    &:last-of-type {
+        margin-bottom: 20px;
+    }
+`;
+
+const Value = styled.div`
+    color: ${props => props.theme.componentsTheme.textColorCommon};
+    flex-shrink: 0;
+    font-feature-settings: 'tnum' 1;
+    font-size: 14px;
+    line-height: 1.2;
+    white-space: nowrap;
+`;
+
+const CostValue = styled(Value)`
+    font-feature-settings: 'tnum' 1;
+    font-weight: bold;
+`;
+
+const StyledTooltip = styled(Tooltip)`
+    margin-left: 5px;
+`;
+
+const LabelContainer = styled.div`
+    align-items: flex-end;
+    display: flex;
+    justify-content: space-between;
+    margin: 5px 0 10px 0;
+`;
+
+const Label = styled.label<{ color?: string }>`
+    color: ${props => props.color || props.theme.componentsTheme.textColorCommon};
+    font-size: 14px;
+    font-weight: 500;
+    line-height: normal;
+    margin: 0;
+`;
+
+const MainLabel = styled(Label)``;
+
+/*const FeeLabel = styled(Label)`
+    color: ${props => props.theme.componentsTheme.textColorCommon};
+    font-weight: normal;
+`;*/
+
+const CostLabel = styled(Label)`
+    font-weight: 700;
+    display: flex;
+`;
+
+const Wave = styled.div``;
+
+const WaveKeyframe = keyframes`
+    0%, 60%, 100% {
+        transform: initial;
+    }
+    30% {
+        transform: translateY(-15px);
+    }
+`;
+const Dot = styled.span`
+    color: ${props => props.theme.componentsTheme.textColorCommon};
+    background-color: ${props => props.theme.componentsTheme.textColorCommon};
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    margin-right: 3px;
+    background: ${props => props.theme.componentsTheme.textColorCommon};
+    animation: ${WaveKeyframe} 1.3s linear infinite;
+
+    &:nth-child(2) {
+        animation-delay: -1.1s;
+    }
+
+    &:nth-child(3) {
+        animation-delay: -0.9s;
+    }
+`;
+
+const AnimatedDots = () => (
+    <Wave>
+        <Dot />
+        <Dot />
+        <Dot />
+    </Wave>
+);
+
+interface OwnProps {
+    tokenAmount: BigNumber;
+    tokenPrice: BigNumber;
+    orderSide: OrderSide;
+    quoteToken: Token;
+    baseToken: Token;
+    buyQuote?: MarketBuySwapQuote;
+    sellQuote?: MarketSellSwapQuote;
+    quoteState: SwapQuoteState;
+}
+
+interface StateProps {
+    qouteInUSD: BigNumber | undefined | null;
+    web3State: Web3State;
+    tokenPrices: TokenPrice[] | null;
+}
+
+interface DispatchProps {
+    onFetchTakerAndMakerFee: (amount: BigNumber, price: BigNumber, side: OrderSide) => Promise<OrderFeeData>;
+}
+
+type Props = StateProps & OwnProps & DispatchProps;
+
+interface State {
+    makerFeeAmount: BigNumber;
+    takerFeeAmount: BigNumber;
+    makerFeeAssetData?: string;
+    takerFeeAssetData?: string;
+    canOrderBeFilled?: boolean;
+    quoteTokenAmount: BigNumber;
+    price: BigNumber;
+    geckoPrice?: BigNumber;
+}
+
+class MarketTradeDetails extends React.Component<Props, State> {
+    public state = {
+        makerFeeAmount: ZERO,
+        takerFeeAmount: ZERO,
+        makerFeeAssetData: NULL_BYTES,
+        takerFeeAssetData: NULL_BYTES,
+        quoteTokenAmount: ZERO,
+        canOrderBeFilled: true,
+        maxAmount: ZERO,
+        price: ZERO,
+        geckoPrice: ZERO,
+    };
+
+    public componentDidUpdate = async (prevProps: Readonly<Props>) => {
+        const newProps = this.props;
+        if (
+            newProps.tokenPrice !== prevProps.tokenPrice ||
+            newProps.tokenAmount !== prevProps.tokenAmount ||
+            newProps.sellQuote !== prevProps.sellQuote ||
+            newProps.buyQuote !== prevProps.buyQuote ||
+            newProps.orderSide !== prevProps.orderSide ||
+            newProps.quoteState !== prevProps.quoteState ||
+        ) {
+            if (newProps.quoteState === SwapQuoteState.Done) {
+                await this._updateOrderDetailsState();
+            }
+        }
+    };
+
+    public componentDidMount = async () => {
+        await this._updateOrderDetailsState();
+    };
+
+    public render = () => {
+        // const fee = this._getFeeStringForRender();
+        const cost = this._getCostStringForRender();
+        const costText = this._getCostLabelStringForRender();
+        const priceMedianText = this._getMedianPriceStringForRender();
+        const priceMarketTrackerText = this._getPriceMarketRender();
+
+        return (
+            <>
+                <LabelContainer>
+                    <MainLabel>Order Details</MainLabel>
+                </LabelContainer>
+                {/* <Row>
+                        <FeeLabel>Fee</FeeLabel>
+                        <Value>{fee}</Value>
+                </Row>*/}
+                <Row>
+                    <CostLabel>
+                        {costText}
+                        <StyledTooltip description="Estimated cost without gas and trade fees" />
+                    </CostLabel>
+                    <CostValue>{cost}</CostValue>
+                </Row>
+                <Row>
+                    <CostLabel>Median Price:</CostLabel>
+                    <CostValue>{priceMedianText}</CostValue>
+                </Row>
+                <Row>
+                    <CostLabel>Price by Coingecko:</CostLabel>
+                    <CostValue>{priceMarketTrackerText}</CostValue>
+                </Row>
+            </>
+        );
+    };
+
+    private readonly _updateOrderDetailsState = async () => {
+        const { sellQuote, orderSide, baseToken, quoteToken, tokenPrices } = this.props;
+        if (!quote) {
+            this.setState({ canOrderBeFilled: false });
+            return;
+        }
+
+        const isSell = orderSide === OrderSide.Sell;
+        const bestQuote = quote.bestCaseQuoteInfo;
+        const worstQuote = quote.worstCaseQuoteInfo;
+        // HACK(dekz): we assume takerFeeAssetData is either empty or is consistent through all orders
+        const takerFeeAssetData = quote.takerAssetData;
+        const takerFeeAmount = worstQuote.feeTakerAssetAmount;
+        const quoteTokenAmount = isSell ? bestQuote.makerAssetAmount : bestQuote.takerAssetAmount;
+        const baseTokenAmount = isSell ? bestQuote.takerAssetAmount : bestQuote.makerAssetAmount;
+        const quoteTokenAmountUnits = new BigNumber(tokenAmountInUnits(quoteTokenAmount, quoteToken.decimals, 18));
+        const baseTokenAmountUnits = new BigNumber(tokenAmountInUnits(baseTokenAmount, baseToken.decimals, 18));
+        const price = quoteTokenAmountUnits.div(baseTokenAmountUnits);
+
+        let geckoPrice;
+        if (tokenPrices) {
+            const tokenPriceQuote = tokenPrices.find(t => t.c_id === quoteToken.c_id);
+            const tokenPriceBase = tokenPrices.find(t => t.c_id === baseToken.c_id);
+            if (tokenPriceQuote && tokenPriceBase) {
+                geckoPrice = tokenPriceBase.price_usd.div(tokenPriceQuote.price_usd);
+            }
+        }
+
+        this.setState({
+            takerFeeAmount,
+            takerFeeAssetData,
+            quoteTokenAmount,
+            canOrderBeFilled: true,
+            price,
+            geckoPrice,
+        });
+    };
+
+    /* private readonly _getFeeStringForRender = () => {
+        const { takerFeeAmount, takerFeeAssetData } = this.state;
+        const { quoteState } = this.props;
+        // If its a Limit order the user is paying a maker fee
+        const feeAssetData = takerFeeAssetData;
+        const feeAmount = takerFeeAmount;
+        if (quoteState === SwapQuoteState.Loading) {
+            return <AnimatedDots />;
+        }
+
+        if (quoteState === SwapQuoteState.Error) {
+            return '0.00';
+        }
+
+        if (feeAssetData === NULL_BYTES) {
+            return '0.00';
+        }
+        const feeToken = getKnownTokens().getTokenByAssetData(feeAssetData);
+
+        return `${tokenAmountInUnits(
+            feeAmount,
+            feeToken.decimals,
+            feeToken.displayDecimals,
+        )} ${tokenSymbolToDisplayString(feeToken.symbol)}`;
+    };*/
+
+    private readonly _getCostStringForRender = () => {
+        const { canOrderBeFilled } = this.state;
+        const { quoteToken, quoteState, tokenPrices } = this.props;
+        if (quoteState === SwapQuoteState.Loading) {
+            return <AnimatedDots />;
+        }
+
+        if (!canOrderBeFilled || quoteState === SwapQuoteState.Error) {
+            return `---`;
+        }
+        let quoteInUSD;
+        if (tokenPrices) {
+            const tokenPrice = tokenPrices.find(t => t.c_id === quoteToken.c_id);
+            if (tokenPrice) {
+                quoteInUSD = tokenPrice.price_usd;
+            }
+        }
+
+        const { quoteTokenAmount } = this.state;
+        const quoteTokenAmountUnits = tokenAmountInUnits(quoteTokenAmount, quoteToken.decimals);
+        const costAmount = tokenAmountInUnits(quoteTokenAmount, quoteToken.decimals, quoteToken.displayDecimals);
+        if (quoteInUSD) {
+            const quotePriceAmountUSD = new BigNumber(quoteTokenAmountUnits).multipliedBy(quoteInUSD);
+            return `${costAmount} ${formatTokenSymbol(quoteToken.symbol)} (${quotePriceAmountUSD.toFixed(2)} $)`;
+        } else {
+            return `${costAmount} ${formatTokenSymbol(quoteToken.symbol)}`;
+        }
+    };
+    private readonly _getMedianPriceStringForRender = () => {
+        const { canOrderBeFilled, price } = this.state;
+
+        const { tokenAmount, quoteToken, quoteState } = this.props;
+
+        if (quoteState === SwapQuoteState.Loading) {
+            return <AnimatedDots />;
+        }
+        if (!canOrderBeFilled || quoteState === SwapQuoteState.Error) {
+            return `---`;
+        }
+        if (tokenAmount.eq(0)) {
+            return `---`;
+        }
+        const priceDisplay = price.toFormat(8);
+        return `${priceDisplay} ${formatTokenSymbol(quoteToken.symbol)}`;
+    };
+
+    private readonly _getCostLabelStringForRender = () => {
+        const { qouteInUSD, orderSide } = this.props;
+        if (qouteInUSD) {
+            return orderSide === OrderSide.Sell ? 'Estimated Total (USD)' : 'Estimated Cost (USD)';
+        } else {
+            return orderSide === OrderSide.Sell ? 'Estimated Total' : 'Estimated Cost';
+        }
+    };
+    private readonly _getPriceMarketRender = () => {
+        const { quoteToken, quoteState } = this.props;
+        const { geckoPrice } = this.state;
+        if (quoteState === SwapQuoteState.Error) {
+            return '---';
+        }
+        if (quoteState === SwapQuoteState.Loading) {
+            return <AnimatedDots />;
+        }
+        if (geckoPrice && geckoPrice.gt(0)) {
+            return `${geckoPrice.toFormat(8)} ${formatTokenSymbol(quoteToken.symbol)}`;
+        }
+        return '---';
+    };
+}
+
+const mapStateToProps = (state: StoreState): StateProps => {
+    return {
+        qouteInUSD: getQuoteInUsd(state),
+        quoteState: getSwapQuoteState(state),
+        tokenPrices: getTokensPrice(state),
+        web3State: getWeb3State(state),
+    };
+};
+
+const mapDispatchToProps = (dispatch: any): DispatchProps => {
+    return {
+        onFetchTakerAndMakerFee: (amount: BigNumber, price: BigNumber, side: OrderSide) =>
+            dispatch(fetchTakerAndMakerFee(amount, price, side, side)),
+    };
+};
+
+const MarketTradeDetailsContainer = connect(mapStateToProps, mapDispatchToProps)(MarketTradeDetails);
+
+export { CostValue, MarketTradeDetails, MarketTradeDetailsContainer, Value };

--- a/src/components/erc20/marketplace/market_maker_stats.tsx
+++ b/src/components/erc20/marketplace/market_maker_stats.tsx
@@ -1,0 +1,118 @@
+import { BigNumber } from '@0x/utils';
+import React from 'react';
+import { useSelector } from 'react-redux';
+import styled from 'styled-components';
+
+import { getCurrentMarketMakerStats } from '../../../store/selectors';
+import { themeBreakPoints } from '../../../themes/commons';
+import { Card } from '../../common/card';
+
+const MarketMakerStatsCard = styled(Card)`
+    height: 300px;
+    overflow: auto;
+    @media (max-width: ${themeBreakPoints.sm}) {
+        max-height: 300px;
+    }
+`;
+
+const Label = styled.label<{ color?: string }>`
+    color: ${props => props.color || props.theme.componentsTheme.textColorCommon};
+    font-size: 14px;
+    font-weight: 500;
+    line-height: normal;
+    margin: 0;
+`;
+
+const Container = styled.div`
+    display: flex;
+    justify-content: space-around;
+    flex-wrap: wrap;
+`;
+
+const Column = styled.div`
+    align-items: center;
+    display: flex;
+    margin: 10px;
+    flex-direction: column;
+    padding: 12px 0;
+    position: relative;
+    z-index: 1;
+    &:last-of-type {
+        margin-bottom: 20px;
+    }
+`;
+
+const fieldsStatsMap = [
+    {
+        label: 'Protocol Fees',
+        field: 'protocolFeesCollected',
+    },
+    {
+        label: 'Weth Fees',
+        field: 'totalWethFeesCollected',
+    },
+    {
+        label: 'Total Orders',
+        field: 'totalOrders',
+    },
+    {
+        label: 'Total Buy Orders',
+        field: 'totalBuyOrders',
+    },
+    {
+        label: 'Total Sell Orders',
+        field: 'totalSellOrders',
+    },
+    {
+        label: 'Median Buy Price',
+        field: 'medianBuyPrice',
+    },
+    {
+        label: 'Median Sell Price',
+        field: 'medianSellPrice',
+    },
+    {
+        label: 'Total Buy Base Volume',
+        field: 'totalBuyBaseVolume',
+    },
+    {
+        label: 'Total Sell Base Volume',
+        field: 'totalSellBaseVolume',
+    },
+    {
+        label: 'Total Buy Quote Volume',
+        field: 'totalBuyQuoteVolume',
+    },
+    {
+        label: 'Total Sell Quote Volume',
+        field: 'totalSellQuoteVolume',
+    },
+    {
+        label: 'Total Quote Volume',
+        field: 'totalQuoteVolume',
+    },
+    {
+        label: 'Total Base Volume',
+        field: 'totalBaseVolume',
+    },
+];
+
+export const MarketMakerStats = () => {
+    let content = null;
+    //
+    const makerStats = useSelector(getCurrentMarketMakerStats) as any;
+
+    content = fieldsStatsMap.map((f: { label: string; field: string }, index) => (
+        <Column key={index}>
+            <Label>{f.label}</Label>
+            <Label>{makerStats ? (makerStats[f.field] as BigNumber).toString() : 0}</Label>
+        </Column>
+    ));
+
+    return (
+        <MarketMakerStatsCard title="Market Maker Stats">
+            {' '}
+            <Container>{content}</Container>
+        </MarketMakerStatsCard>
+    );
+};

--- a/src/components/erc20/marketplace/market_trade.tsx
+++ b/src/components/erc20/marketplace/market_trade.tsx
@@ -306,7 +306,7 @@ const MarketTrade = (props: Props) => {
                 });
             }
         }
-    }, [swapQuoteState]);
+    }, [swapQuoteState, errorState]);
 
     useEffect(() => {
         if (debouncedAmount) {

--- a/src/components/erc20/marketplace/order_book.tsx
+++ b/src/components/erc20/marketplace/order_book.tsx
@@ -14,7 +14,12 @@ import {
     getUserOrders,
     getWeb3State,
 } from '../../../store/selectors';
-import { setMakerAmountSelected, setOrderPriceSelected } from '../../../store/ui/actions';
+import {
+    setMakerAmountSelected,
+    setOrderBuyPriceSelected,
+    setOrderPriceSelected,
+    setOrderSellPriceSelected,
+} from '../../../store/ui/actions';
 import { Theme, themeBreakPoints } from '../../../themes/commons';
 import { formatTokenSymbol, tokenAmountInUnits } from '../../../util/tokens';
 import {
@@ -58,6 +63,7 @@ interface StateProps {
 
 interface OwnProps {
     theme: Theme;
+    defaultDepth?: number;
 }
 
 type Props = OwnProps & StateProps;
@@ -214,6 +220,8 @@ interface OrderToRowPropsOwn {
 
 interface OrderToRowDispatchProps {
     onSetOrderPriceSelected: (orderPriceSelected: BigNumber) => Promise<any>;
+    onSetOrderBuyPriceSelected: (orderPriceSelected: BigNumber) => Promise<any>;
+    onSetOrderSellPriceSelected: (orderPriceSelected: BigNumber) => Promise<any>;
     onSetMakerAmountSelected: (makerAmountSelected: BigNumber) => Promise<any>;
 }
 
@@ -306,6 +314,11 @@ class OrderToRow extends React.Component<OrderToRowProps> {
                 return sumSize;
             }, ZERO);
         }
+        if (order.side === OrderSide.Buy) {
+            await this.props.onSetOrderBuyPriceSelected(size);
+        } else {
+            await this.props.onSetOrderSellPriceSelected(size);
+        }
 
         await this.props.onSetOrderPriceSelected(size);
         await this.props.onSetMakerAmountSelected(totalSize);
@@ -315,6 +328,10 @@ class OrderToRow extends React.Component<OrderToRowProps> {
 const mapOrderToRowDispatchToProps = (dispatch: any): OrderToRowDispatchProps => {
     return {
         onSetOrderPriceSelected: (orderPriceSelected: BigNumber) => dispatch(setOrderPriceSelected(orderPriceSelected)),
+        onSetOrderBuyPriceSelected: (orderPriceSelected: BigNumber) =>
+            dispatch(setOrderBuyPriceSelected(orderPriceSelected)),
+        onSetOrderSellPriceSelected: (orderPriceSelected: BigNumber) =>
+            dispatch(setOrderSellPriceSelected(orderPriceSelected)),
         onSetMakerAmountSelected: (makerAmountSelected: BigNumber) =>
             dispatch(setMakerAmountSelected(makerAmountSelected)),
     };
@@ -334,7 +351,7 @@ interface StateOrderBook {
 }
 class OrderBookTable extends React.Component<Props, StateOrderBook> {
     public state = {
-        depth: { value: 5 },
+        depth: { value: this.props.defaultDepth || 5 },
         bookOption: BookOptionType.BuySellBook,
     };
 

--- a/src/components/erc20/marketplace/order_details.tsx
+++ b/src/components/erc20/marketplace/order_details.tsx
@@ -9,7 +9,7 @@ import { fetchTakerAndMakerFee } from '../../../store/relayer/actions';
 import { getOpenBuyOrders, getOpenSellOrders, getQuoteInUsd } from '../../../store/selectors';
 import { getKnownTokens } from '../../../util/known_tokens';
 import { buildMarketOrders, sumTakerAssetFillableOrders } from '../../../util/orders';
-import { formatTokenSymbol, tokenAmountInUnits } from '../../../util/tokens';
+import { formatTokenSymbol, tokenAmountInUnits, unitsInTokenAmount } from '../../../util/tokens';
 import { CurrencyPair, OrderFeeData, OrderSide, OrderType, StoreState, UIOrder } from '../../../util/types';
 
 const Row = styled.div`
@@ -164,10 +164,7 @@ class OrderDetails extends React.Component<Props, State> {
             const quoteToken = getKnownTokens().getTokenBySymbol(quote);
             const baseToken = getKnownTokens().getTokenBySymbol(base);
             // TODO: Check if this precision is enough, price was giving error on precision
-            const priceInQuoteBaseUnits = Web3Wrapper.toBaseUnitAmount(
-                new BigNumber(tokenPrice.toFixed(18)),
-                quoteToken.decimals,
-            );
+            const priceInQuoteBaseUnits = unitsInTokenAmount(tokenPrice.toString(), quoteToken.decimals);
             const baseTokenAmountInUnits = Web3Wrapper.toUnitAmount(tokenAmount, baseToken.decimals);
             const quoteTokenAmount = baseTokenAmountInUnits.multipliedBy(priceInQuoteBaseUnits);
             const { makerFee, makerFeeAssetData, takerFee, takerFeeAssetData } = await onFetchTakerAndMakerFee(

--- a/src/components/erc20/marketplace/wizard_form/tokens_form.tsx
+++ b/src/components/erc20/marketplace/wizard_form/tokens_form.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
-import { FieldArray, useFieldArray } from 'react-final-form-arrays';
+import { FieldArray, FieldArrayRenderProps, useFieldArray } from 'react-final-form-arrays';
 import { Field } from 'react-final-form-html5-validation';
 import { OnChange } from 'react-final-form-listeners';
 import styled from 'styled-components';
 
+import { getAvailableMarkets } from '../../../../common/markets';
 import { getERC20ContractWrapper } from '../../../../services/contract_wrappers';
 import { getTokenByAddress } from '../../../../services/tokens';
 import { themeDimensions } from '../../../../themes/commons';
@@ -34,6 +35,17 @@ const StyledToken = styled.div`
     border-radius: ${themeDimensions.borderRadius};
     border: 1px solid ${props => props.theme.componentsTheme.cardBorderColor};
 `;
+
+/*const CheckBoxQuoteColumn = styled.div`
+    display: flex;
+    flex-direction: column;
+    margin: 10px;
+`;
+
+const CheckBoxQuoteContainer = styled.div`
+    display: flex;
+    flex-direction: row;
+`;*/
 
 const StyledFieldContainer = styled(FieldContainer)`
     display: flex;
@@ -96,6 +108,44 @@ export const TokensForm = ({
         </>
     );
 };
+
+/*const QuoteCheckboxs = (baseSymbol: string, marketFilters: any[], pairsArray: FieldArrayRenderProps<any, any>) => {
+    const availableMarkets = getAvailableMarkets();
+    return marketFilters.map((m: { text: string; value: string }, i) => {
+        const value = availableMarkets.findIndex(a => a.base.toLowerCase() === baseSymbol.toLowerCase() && a.quote.toLowerCase() === m.value.toLowerCase()) !== -1;
+        const onClickQuote = () => {
+            const { fields } = pairsArray;
+            if (value) {
+                const index = fields.value.findIndex(a => a.base.toLowerCase() === baseSymbol.toLowerCase() && a.quote.toLowerCase() === m.value.toLowerCase());
+                if (index !== -1) {
+                    fields.remove(index);
+                }
+            } else {
+                fields.unshift({
+                    base: baseSymbol.toLowerCase(),
+                    quote: m.value.toLowerCase(),
+                    config: {
+                        basePrecision: 2,
+                        pricePrecision: 8,
+                        minAmount: 1,
+                    },
+                });
+            }
+        };
+        return <CheckBoxQuoteColumn key={i}>
+            <LabelContainer>
+                <Label>{m.text}</Label>
+            </LabelContainer>
+            <FieldContainer >
+                <input
+                    type={'checkbox'}
+                    checked={value}
+                    onClick={onClickQuote}
+                />
+            </FieldContainer>
+        </CheckBoxQuoteColumn>;
+    });
+};*/
 
 const TokenForm = ({ name, index }: { name: string; index: number }) => {
     const [isEdit, setIsEdit] = useState(false);
@@ -245,6 +295,9 @@ const TokenForm = ({ name, index }: { name: string; index: number }) => {
                 <FieldContainer>
                     <Field name={`${name}.c_id`} type={'hidden'} component={StyledInput} placeholder={`Coingecko id`} />
                 </FieldContainer>
+                {/*<CheckBoxQuoteContainer>
+                    QuoteCheckboxs(value.symbol, marketFilters, pairsArray)
+                </CheckBoxQuoteContainer>*/}
             </>
         );
     } else {

--- a/src/components/erc20/pages/market_maker.tsx
+++ b/src/components/erc20/pages/market_maker.tsx
@@ -7,7 +7,11 @@ import { FiatChooseModalContainer } from '../../account/fiat_onchoose_modal';
 import { CheckWalletStateModalContainer } from '../../common/check_wallet_state_modal_container';
 import { ColumnWide } from '../../common/column_wide';
 import { Content } from '../common/content_wrapper';
+import { MarketFillsContainer } from '../marketplace/market_fills';
 import { MarketMakerContainer } from '../marketplace/market_maker';
+import { MarketMakerStats } from '../marketplace/market_maker_stats';
+import { OrderBookTableContainer } from '../marketplace/order_book';
+import { OrderHistoryContainer } from '../marketplace/order_history';
 
 const ColumnWideMyWallet = styled(ColumnWide)`
     margin-left: 0;
@@ -27,15 +31,35 @@ const CenteredContent = styled(Content)`
     justify-content: center;
 `;
 
+const OrderHistoryStyled = styled(OrderHistoryContainer)`
+    max-height: 500px;
+`;
+
+const MarketFillsContainerStyled = styled(MarketFillsContainer)`
+    min-width: 200px;
+`;
+
 const MarketMakerPage = () => (
-    <CenteredContent>
-        <ColumnWideMyWallet>
-            <MarketMakerContainer />
-        </ColumnWideMyWallet>
-        <CheckWalletStateModalContainer />
-        <FiatOnRampModalContainer />
-        <FiatChooseModalContainer />
-    </CenteredContent>
+    <>
+        <CenteredContent>
+            <ColumnWideMyWallet>
+                <MarketMakerContainer />
+            </ColumnWideMyWallet>
+            <OrderBookTableContainer defaultDepth={50} />
+            <MarketFillsContainerStyled />
+            <CheckWalletStateModalContainer />
+            <FiatOnRampModalContainer />
+            <FiatChooseModalContainer />
+        </CenteredContent>
+        <Content>
+            <ColumnWideMyWallet>
+                <OrderHistoryStyled />
+            </ColumnWideMyWallet>
+            <ColumnWideMyWallet>
+                <MarketMakerStats />
+            </ColumnWideMyWallet>
+        </Content>
+    </>
 );
 
 export { MarketMakerPage as default };

--- a/src/components/erc20/pages/market_maker.tsx
+++ b/src/components/erc20/pages/market_maker.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { themeBreakPoints } from '../../../themes/commons';
+import { FiatOnRampModalContainer } from '../../account/fiat_modal';
+import { FiatChooseModalContainer } from '../../account/fiat_onchoose_modal';
+import { CheckWalletStateModalContainer } from '../../common/check_wallet_state_modal_container';
+import { ColumnWide } from '../../common/column_wide';
+import { Content } from '../common/content_wrapper';
+import { MarketMakerContainer } from '../marketplace/market_maker';
+
+const ColumnWideMyWallet = styled(ColumnWide)`
+    margin-left: 0;
+    &:last-child {
+        margin-left: 0;
+    }
+    @media (max-width: ${themeBreakPoints.sm}) {
+        width: 100%;
+    }
+    @media (min-width: ${themeBreakPoints.md}) {
+        max-width: 60%;
+    }
+`;
+
+const CenteredContent = styled(Content)`
+    align-items: center;
+    justify-content: center;
+`;
+
+const MarketMakerPage = () => (
+    <CenteredContent>
+        <ColumnWideMyWallet>
+            <MarketMakerContainer />
+        </ColumnWideMyWallet>
+        <CheckWalletStateModalContainer />
+        <FiatOnRampModalContainer />
+        <FiatChooseModalContainer />
+    </CenteredContent>
+);
+
+export { MarketMakerPage as default };

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,23 +1,23 @@
 // Use this on production
-/*import configFileProduction from '../config/files/config.json';
+import configFileProduction from '../config/files/config.json';
 
 import collectibleCollectionConfig from './collectibles-config.json';
 import configTemplateFile from './config-template.json';
 import configFileTest from './config-test.json';
 import configFileIEOProduction from './files/config-ieo.json';
 import configTipBot from './files/settingsAssets.json';
-import configTipBotWhitelistAddresses from './files/settingsAssetsWhitelistAddresses.json';*/
+import configTipBotWhitelistAddresses from './files/settingsAssetsWhitelistAddresses.json';
 // import configFileProduction from '../config/files/config2.json';
 // Using this due to CI error
 
 // import configFileProduction from '../config/files/config.json';
-import collectibleCollectionConfig from './collectibles-config.json';
+/*import collectibleCollectionConfig from './collectibles-config.json';
 import configFileIEOProduction from './config-ieo.json';
 import configTemplateFile from './config-template.json';
 import configFileTest from './config-test.json';
 import configFileProduction from './config.json';
 import configTipBot from './settingsAssets.json';
-import configTipBotWhitelistAddresses from './settingsAssetsWhitelistAddresses.json';
+import configTipBotWhitelistAddresses from './settingsAssetsWhitelistAddresses.json';*/
 
 // import configFileTest from './config-test.json';
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,23 +1,23 @@
 // Use this on production
-import configFileProduction from '../config/files/config.json';
+/*import configFileProduction from '../config/files/config.json';
 
 import collectibleCollectionConfig from './collectibles-config.json';
 import configTemplateFile from './config-template.json';
 import configFileTest from './config-test.json';
 import configFileIEOProduction from './files/config-ieo.json';
 import configTipBot from './files/settingsAssets.json';
-import configTipBotWhitelistAddresses from './files/settingsAssetsWhitelistAddresses.json';
+import configTipBotWhitelistAddresses from './files/settingsAssetsWhitelistAddresses.json';*/
 // import configFileProduction from '../config/files/config2.json';
 // Using this due to CI error
 
 // import configFileProduction from '../config/files/config.json';
-/*import collectibleCollectionConfig from './collectibles-config.json';
+import collectibleCollectionConfig from './collectibles-config.json';
 import configFileIEOProduction from './config-ieo.json';
 import configTemplateFile from './config-template.json';
 import configFileTest from './config-test.json';
 import configFileProduction from './config.json';
 import configTipBot from './settingsAssets.json';
-import configTipBotWhitelistAddresses from './settingsAssetsWhitelistAddresses.json';*/
+import configTipBotWhitelistAddresses from './settingsAssetsWhitelistAddresses.json';
 
 // import configFileTest from './config-test.json';
 

--- a/src/services/local_storage.ts
+++ b/src/services/local_storage.ts
@@ -248,9 +248,11 @@ export class LocalStorage {
             this._storage.setItem(themeNameKey, JSON.stringify(themeName));
         }
     }
-    public saveUserConfigData(userConfigData?: UserConfigData): void {
+    public saveUserConfigData(userConfigData?: UserConfigData | null): void {
         if (userConfigData) {
             this._storage.setItem(userConfigDataKey, JSON.stringify(userConfigData));
+        } else {
+            this._storage.removeItem(userConfigDataKey);
         }
     }
 }

--- a/src/services/web3_wrapper.ts
+++ b/src/services/web3_wrapper.ts
@@ -290,3 +290,7 @@ export const getWeb3Wrapper = async (): Promise<Web3Wrapper> => {
 export const deleteWeb3Wrapper = (): void => {
     web3Wrapper = null;
 };
+
+export const isWeb3Wrapper = (): Web3Wrapper | null => {
+    return web3Wrapper;
+};

--- a/src/store/blockchain/actions.ts
+++ b/src/store/blockchain/actions.ts
@@ -16,7 +16,7 @@ import {
     USE_RELAYER_MARKET_UPDATES,
     ZERO,
 } from '../../common/constants';
-import { addAvailableMarket } from '../../common/markets';
+import { addWethAvailableMarket } from '../../common/markets';
 import { ConvertBalanceMustNotBeEqualException } from '../../exceptions/convert_balance_must_not_be_equal_exception';
 import { SignedOrderException } from '../../exceptions/signed_order_exception';
 import { getConfiguredSource } from '../../services/collectibles_metadata_sources';
@@ -652,7 +652,7 @@ const initWalletERC20: ThunkCreator<Promise<any>> = () => {
             const knownTokens = getKnownTokens();
             if (base && Web3Wrapper.isAddress(base) && !knownTokens.isKnownAddress(base)) {
                 const tokenToAdd = await knownTokens.addTokenByAddress(base);
-                const market = tokenToAdd && addAvailableMarket(tokenToAdd);
+                const market = tokenToAdd && addWethAvailableMarket(tokenToAdd);
                 if (market) {
                     dispatch(setCurrencyPair(market));
                 }
@@ -953,7 +953,7 @@ export const initializeAppWallet: ThunkCreator = () => {
                 };
                 tokenToAdd = await knownTokens.fetchTokenMetadaFromGecko(tokenToAdd);
                 knownTokens.pushToken(tokenToAdd);
-                const market = addAvailableMarket(tokenToAdd);
+                const market = addWethAvailableMarket(tokenToAdd);
                 if (market) {
                     dispatch(setCurrencyPair(market));
                 }

--- a/src/store/market/reducers.ts
+++ b/src/store/market/reducers.ts
@@ -39,6 +39,7 @@ const initialMarketState: MarketState = {
     marketStats: null,
     makerAddresses: getMakerAddresses(),
     marketsStats: [],
+    marketMakerStats: [],
 };
 
 export function market(state: MarketState = initialMarketState, action: RootAction): MarketState {
@@ -51,6 +52,8 @@ export function market(state: MarketState = initialMarketState, action: RootActi
             return { ...state, markets: action.payload };
         case getType(actions.setMarketsStats):
             return { ...state, marketsStats: action.payload };
+        case getType(actions.setMarketMakerStats):
+            return { ...state, marketMakerStats: action.payload };
         case getType(actions.fetchMarketPriceEtherUpdate):
             return { ...state, ethInUsd: action.payload };
         case getType(actions.fetchMarketPriceEtherStart):

--- a/src/store/middlewares.ts
+++ b/src/store/middlewares.ts
@@ -171,9 +171,9 @@ export const localStorageMiddleware: Middleware = ({ getState }: MiddlewareAPI) 
         case getType(actions.setUserConfigData): {
             const state = getState();
             const config = getUserConfigData(state);
-            if (config) {
-                localStorage.saveUserConfigData(config);
-            }
+            // Note: If null it will remove
+            localStorage.saveUserConfigData(config);
+
             break;
         }
 

--- a/src/store/router/actions.ts
+++ b/src/store/router/actions.ts
@@ -38,6 +38,18 @@ const goToHomeErc20: ThunkCreator = () => {
     };
 };
 
+export const goToHomeMarketMaker: ThunkCreator = () => {
+    return async (dispatch, getState) => {
+        const state = getState();
+        dispatch(
+            push({
+                ...state.router.location,
+                pathname: `${ERC20_APP_BASE_PATH}/market-maker`,
+            }),
+        );
+    };
+};
+
 export const goToHomeLaunchpad: ThunkCreator = () => {
     return async (dispatch, getState) => {
         const state = getState();

--- a/src/store/selectors.ts
+++ b/src/store/selectors.ts
@@ -27,6 +27,7 @@ import {
     CurrencyPair,
     Fill,
     MarketFill,
+    MarketMakerStats,
     MARKETPLACES,
     OrderBook,
     OrderSide,
@@ -53,7 +54,10 @@ export const getWethBalance = (state: StoreState) =>
     state.blockchain.wethTokenBalance ? state.blockchain.wethTokenBalance.balance : ZERO;
 export const getOrders = (state: StoreState) => state.relayer.orders;
 export const getUserOrders = (state: StoreState) => state.relayer.userOrders;
+export const getOrderSecondsExpirationTime = (state: StoreState) => state.ui.orderSecondsExpirationTime;
 export const getOrderPriceSelected = (state: StoreState) => state.ui.orderPriceSelected;
+export const getOrderBuyPriceSelected = (state: StoreState) => state.ui.orderBuyPriceSelected;
+export const getOrderSellPriceSelected = (state: StoreState) => state.ui.orderSellPriceSelected;
 export const getMakerAmountSelected = (state: StoreState) => state.ui.makerAmountSelected;
 export const getNotifications = (state: StoreState) => state.ui.notifications;
 export const getFills = (state: StoreState) => state.ui.fills;
@@ -99,6 +103,7 @@ export const getERC20Layout = (state: StoreState) => state.ui.erc20Layout;
 export const getDynamicLayout = (state: StoreState) => state.ui.isDynamicLayout;
 export const getMarketStats = (state: StoreState) => state.market.marketStats;
 export const getMarketsStats = (state: StoreState) => state.market.marketsStats;
+export const getMarketMakerStats = (state: StoreState) => state.market.marketMakerStats;
 export const getFeeRecipient = (state: StoreState) => state.relayer.feeRecipient;
 export const getFeePercentage = (state: StoreState) => state.relayer.feePercentage;
 export const getSwapQuoteToken = (state: StoreState) => state.swap.quoteToken;
@@ -217,6 +222,14 @@ export const getTotalEthBalance = createSelector(
     getEthBalance,
     getWethBalance,
     (ethBalance: BigNumber, wethTokenBalance: BigNumber) => ethBalance.plus(wethTokenBalance),
+);
+
+export const getCurrentMarketMakerStats = createSelector(
+    getMarketMakerStats,
+    getEthAccount,
+    getCurrencyPair,
+    (marketStats: MarketMakerStats[], ethAccount: string, currencyPair: CurrencyPair) =>
+        marketStats.find(m => m.account.toLowerCase() === ethAccount && m.market === marketToString(currencyPair)),
 );
 
 export const getBaseTokenBalance = createSelector(

--- a/src/store/ui/reducers.ts
+++ b/src/store/ui/reducers.ts
@@ -45,6 +45,8 @@ const initialUIState: UIState = {
     hasUnreadNotifications: false,
     stepsModal: initialStepsModalState,
     orderPriceSelected: null,
+    orderBuyPriceSelected: null,
+    orderSellPriceSelected: null,
     makerAmountSelected: null,
     sidebarOpen: false,
     fiatType: 'APPLE_PAY',
@@ -98,8 +100,14 @@ export function ui(state: UIState = initialUIState, action: RootAction): UIState
     switch (action.type) {
         case getType(actions.setHasUnreadNotifications):
             return { ...state, hasUnreadNotifications: action.payload };
+        case getType(actions.setOrderSecondsExpirationTime):
+            return { ...state, orderSecondsExpirationTime: action.payload };
         case getType(actions.setOrderPriceSelected):
             return { ...state, orderPriceSelected: action.payload };
+        case getType(actions.setOrderBuyPriceSelected):
+            return { ...state, orderBuyPriceSelected: action.payload };
+        case getType(actions.setOrderSellPriceSelected):
+            return { ...state, orderSellPriceSelected: action.payload };
         case getType(actions.setMakerAmountSelected):
             return { ...state, makerAmountSelected: action.payload };
         case getType(actions.setNotifications):

--- a/src/tests/util/known_tokens.test.ts
+++ b/src/tests/util/known_tokens.test.ts
@@ -42,6 +42,7 @@ const wethToken: Token = {
     maxAmount: undefined,
     precision: 8,
     id: 'ethereum',
+    listed: true,
 };
 const zrxToken: Token = {
     address: dummyTokensMetaData[1].addresses[NETWORK_ID],
@@ -55,6 +56,7 @@ const zrxToken: Token = {
     maxAmount: undefined,
     minAmount: 0,
     precision: 2,
+    listed: true,
 };
 
 const fillEvent1 = {

--- a/src/util/known_tokens_ieo.ts
+++ b/src/util/known_tokens_ieo.ts
@@ -5,6 +5,7 @@ import { AssetProxyId } from '@0x/types';
 import { ConfigIEO } from '../common/config';
 import { KNOWN_TOKENS_META_DATA } from '../common/tokens_meta_data';
 import { KNOWN_TOKENS_IEO_META_DATA, TokenIEOMetaData } from '../common/tokens_meta_data_ieo';
+import { isWeb3Wrapper } from '../services/web3_wrapper';
 
 import { getKnownTokens, getTokenMetadaDataFromContract, getTokenMetadaDataFromServer } from './known_tokens';
 import { getLogger } from './logger';
@@ -119,7 +120,12 @@ export class KnownTokensIEO {
         }
         let token;
         try {
-            token = await getTokenMetadaDataFromContract(address);
+            // Note: We need to check if web3 is enabled because it will be awaiting
+            if (isWeb3Wrapper()) {
+                token = await getTokenMetadaDataFromContract(address);
+            } else {
+                token = await getTokenMetadaDataFromServer(address);
+            }
         } catch {
             token = await getTokenMetadaDataFromServer(address);
         }

--- a/src/util/market_maker.ts
+++ b/src/util/market_maker.ts
@@ -1,0 +1,53 @@
+import { BigNumber, MarketBuySwapQuote, MarketSellSwapQuote } from '@0x/asset-swapper';
+
+import { tokenAmountInUnits } from './tokens';
+import { Token } from './types';
+
+export const computePriceFromQuote = (
+    isSell: boolean,
+    quote: MarketBuySwapQuote | MarketSellSwapQuote,
+    baseToken: Token,
+    quoteToken: Token,
+): BigNumber => {
+    const bestQuote = quote.bestCaseQuoteInfo;
+    const quoteTokenAmount = isSell ? bestQuote.makerAssetAmount : bestQuote.takerAssetAmount;
+    const baseTokenAmount = isSell ? bestQuote.takerAssetAmount : bestQuote.makerAssetAmount;
+    const quoteTokenAmountUnits = new BigNumber(tokenAmountInUnits(quoteTokenAmount, quoteToken.decimals, 18));
+    const baseTokenAmountUnits = new BigNumber(tokenAmountInUnits(baseTokenAmount, baseToken.decimals, 18));
+    const price = quoteTokenAmountUnits.div(baseTokenAmountUnits);
+    return price;
+};
+
+export const computeSpreadPercentage = (buyPrice: BigNumber, sellPrice: BigNumber): BigNumber => {
+    return sellPrice
+        .minus(buyPrice)
+        .div(sellPrice)
+        .multipliedBy(100);
+};
+
+export const getPricesFromSpread = (
+    buyPrice: BigNumber,
+    sellPrice: BigNumber,
+    newSpreadPercentage: BigNumber,
+): [BigNumber, BigNumber] => {
+    const newSpreadUnits = newSpreadPercentage.dividedBy(100);
+    // Increment = (BuyPrice - SellPrice *(1-newSpread))/(2 - newSpread)
+    const incrementPrice = buyPrice
+        .minus(sellPrice.multipliedBy(new BigNumber(1).minus(newSpreadUnits)))
+        .dividedBy(new BigNumber(2).minus(newSpreadUnits));
+    const newBuyPrice = buyPrice.minus(incrementPrice);
+    const newSellPrice = sellPrice.plus(incrementPrice);
+    return [newBuyPrice, newSellPrice];
+};
+
+export const computeOrderSizeFromInventoryBalance = (
+    amount: BigNumber,
+    inventoryBalance: BigNumber,
+    isBuy: boolean,
+): BigNumber => {
+    if (isBuy) {
+        return amount.multipliedBy(2).multipliedBy(inventoryBalance);
+    } else {
+        return amount.multipliedBy(2).multipliedBy(new BigNumber(1).minus(inventoryBalance));
+    }
+};

--- a/src/util/time_utils.ts
+++ b/src/util/time_utils.ts
@@ -19,6 +19,10 @@ export const getExpirationTimeFromDate = (timestamp: number | string) => {
     return new BigNumber(Math.floor(new Date(timestamp).valueOf() / 1000));
 };
 
+export const getExpirationTimeFromSeconds = (seconds: BigNumber) => {
+    return new BigNumber(Math.floor(new Date().valueOf() / 1000) + seconds.toNumber());
+};
+
 export const todayInSeconds = () => {
     return Math.floor(Date.now() / 1000);
 };

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -123,6 +123,13 @@ export enum Web3State {
     Locked = 'Locked',
 }
 
+export enum ServerState {
+    Done = 'Done',
+    Error = 'Error',
+    Loading = 'Loading',
+    NotLoaded = 'NotLoaded',
+}
+
 export enum SwapQuoteState {
     Done = 'Done',
     Error = 'Error',
@@ -164,6 +171,7 @@ export interface RelayerState {
     readonly accountMarketStats?: AccountMarketStat[];
     readonly feeRecipient?: string;
     readonly feePercentage?: number;
+    readonly orderExpireTime?: number;
 }
 
 export interface SwapState {
@@ -184,6 +192,8 @@ export interface UIState {
     readonly stepsModal: StepsModalState;
     readonly startTour: boolean;
     readonly orderPriceSelected: BigNumber | null;
+    readonly orderBuyPriceSelected: BigNumber | null;
+    readonly orderSellPriceSelected: BigNumber | null;
     readonly makerAmountSelected: BigNumber | null;
     readonly sidebarOpen: boolean;
     readonly openFiatOnRampModal: boolean;
@@ -194,8 +204,9 @@ export interface UIState {
     readonly isDynamicLayout: boolean;
     readonly themeName: string;
     readonly generalConfig?: GeneralConfig;
-    readonly configData?: ConfigData | null;
     readonly userConfigData: UserConfigData | null;
+    readonly configData?: ConfigData | null;
+    readonly orderSecondsExpirationTime?: BigNumber | null;
 }
 
 export interface MarketState {
@@ -209,6 +220,7 @@ export interface MarketState {
     readonly marketStats: RelayerMarketStats | null;
     readonly makerAddresses: string[] | null;
     readonly marketsStats?: RelayerMarketStats[] | null;
+    readonly marketMakerStats: MarketMakerStats[];
 }
 
 export interface StoreState {
@@ -437,6 +449,30 @@ export interface Fill {
     market: string;
 }
 
+export interface UserMarketMakerStats {
+    [market: string]: MarketMakerStats;
+}
+
+export interface MarketMakerStats {
+    market: string;
+    account: string;
+    protocolFeesCollected: BigNumber;
+    totalWethFeesCollected: BigNumber;
+    totalOrders: BigNumber;
+    totalBuyOrders: BigNumber;
+    totalSellOrders: BigNumber;
+    medianBuyPrice: BigNumber;
+    medianSellPrice: BigNumber;
+    totalBuyQuoteVolume: BigNumber;
+    totalBuyBaseVolume: BigNumber;
+    totalSellQuoteVolume: BigNumber;
+    totalSellBaseVolume: BigNumber;
+    totalQuoteVolume: BigNumber;
+    totalBaseVolume: BigNumber;
+    startingStats: Date;
+    endStats: Date;
+}
+
 export interface RelayerFill {
     id: string;
     tradeId: number;
@@ -450,6 +486,9 @@ export interface RelayerFill {
     feeRecipientAddress: string;
     makerFee: string;
     takerFee: string;
+    makerFeeAddress: string;
+    takerFeeAddress: string;
+    protocolFeePaid: string;
     filledTokenBaseAmount: string;
     filledTokenQuoteAmount: string;
     price: string;
@@ -507,6 +546,9 @@ export interface OrderFilledMessage {
         feeRecipientAddress: string;
         makerFeePaid: string;
         takerFeePaid: string;
+        takerFeeAddress: string;
+        makerFeeAddress: string;
+        protocolFeePaid: string;
         filledBaseTokenAmount: string;
         filledQuoteTokenAmount: string;
         orderHash: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -46,19 +46,19 @@
     lodash "^4.17.11"
     valid-url "^1.0.9"
 
-"@0x/asset-swapper@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/@0x/asset-swapper/-/asset-swapper-4.2.0.tgz#73554c15f2c0c35106359228a94dcdf04fc8123e"
-  integrity sha512-jHrtyjPsUYLGWoMmolG4c7Y1TMnTOOn0W7K0qtL5rAlc8GQ3WVal8ZMA31bJrAit1N0rOwYQY0HCXAEuj8jcwg==
+"@0x/asset-swapper@^4.4.0":
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/@0x/asset-swapper/-/asset-swapper-4.4.0.tgz#bde12000964e5132805ded134908da0d494b2f32"
+  integrity sha512-acs0RXtOcR65kift8Mj9wtvx9uvsUqFDtfRd59pu+yA3IiNRf83PL7uvvph2YsrD2z8zdvBjf3PisSGxRqWKCQ==
   dependencies:
-    "@0x/assert" "^3.0.6"
-    "@0x/contract-addresses" "^4.6.0"
-    "@0x/contract-wrappers" "^13.6.0"
-    "@0x/json-schemas" "^5.0.6"
-    "@0x/order-utils" "^10.2.1"
-    "@0x/orderbook" "^2.2.1"
-    "@0x/utils" "^5.4.0"
-    "@0x/web3-wrapper" "^7.0.6"
+    "@0x/assert" "^3.0.7"
+    "@0x/contract-addresses" "^4.9.0"
+    "@0x/contract-wrappers" "^13.6.3"
+    "@0x/json-schemas" "^5.0.7"
+    "@0x/order-utils" "^10.2.4"
+    "@0x/orderbook" "^2.2.5"
+    "@0x/utils" "^5.4.1"
+    "@0x/web3-wrapper" "^7.0.7"
     heartbeats "^5.0.1"
     lodash "^4.17.11"
 
@@ -71,23 +71,6 @@
     "@0x/json-schemas" "^5.0.4"
     "@0x/utils" "^5.2.0"
     "@0x/web3-wrapper" "^7.0.4"
-    ethereumjs-account "^3.0.0"
-    ethereumjs-blockstream "^7.0.0"
-    ethereumjs-util "^5.1.1"
-    ethereumjs-vm "^4.0.0"
-    ethers "~4.0.4"
-    js-sha3 "^0.7.0"
-    uuid "^3.3.2"
-
-"@0x/base-contract@^6.2.0":
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/@0x/base-contract/-/base-contract-6.2.0.tgz#9da77f751529ffbc68a981954dabf7b40aab2abe"
-  integrity sha512-XoaxY0mJLgvbRNV/IL8f2K7P4yek6XeP+xWbfAjm9CbXfiiHDHoYJ12QdatEpxNro9KoJy3jZCBJKdFssdu92g==
-  dependencies:
-    "@0x/assert" "^3.0.6"
-    "@0x/json-schemas" "^5.0.6"
-    "@0x/utils" "^5.4.0"
-    "@0x/web3-wrapper" "^7.0.6"
     ethereumjs-account "^3.0.0"
     ethereumjs-blockstream "^7.0.0"
     ethereumjs-util "^5.1.1"
@@ -129,17 +112,26 @@
     uuid "^3.3.2"
     websocket "^1.0.26"
 
+"@0x/connect@^6.0.7":
+  version "6.0.7"
+  resolved "https://registry.yarnpkg.com/@0x/connect/-/connect-6.0.7.tgz#9c9bfbd259e8b346116e876456f1b76afc6d6f4b"
+  integrity sha512-oY4bEkuyNLqU6SgryLLhb9Fd+7snOL7WpQ043rI8f1a4XLA1GqukZ7luuoTHWRjJta9I7cLGwjt9oDiIgTDcZw==
+  dependencies:
+    "@0x/assert" "^3.0.7"
+    "@0x/json-schemas" "^5.0.7"
+    "@0x/types" "^3.1.2"
+    "@0x/typescript-typings" "^5.0.2"
+    "@0x/utils" "^5.4.1"
+    lodash "^4.17.11"
+    query-string "^6.0.0"
+    sinon "^4.0.0"
+    uuid "^3.3.2"
+    websocket "^1.0.26"
+
 "@0x/contract-addresses@^4.3.0":
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/@0x/contract-addresses/-/contract-addresses-4.3.0.tgz#3026a03a7b02e68d30d9ecea6b7520d2af6d6ea6"
   integrity sha512-LT2SFXBgfCQ4/C7cPZdnoWc7/fdlcOab5O6qPPIpk0t1EFOepiIRCluAao8HWgCwuOt3iQAuRV+bdtoYv+Y2Gw==
-  dependencies:
-    lodash "^4.17.11"
-
-"@0x/contract-addresses@^4.6.0":
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/@0x/contract-addresses/-/contract-addresses-4.6.0.tgz#98ff1546b86b1a4ba198b46d7380de420333f93c"
-  integrity sha512-uWT5e8hAeE4a0dnzGXCEy5B1iSCVPJ05zfiN+hIpYE8NOWc9VMR6HKsplFDivFWJw5UKEsdlMBsXszCr2sRWfw==
   dependencies:
     lodash "^4.17.11"
 
@@ -163,21 +155,6 @@
     ethereum-types "^3.0.0"
     ethers "~4.0.4"
 
-"@0x/contract-wrappers@^13.6.0":
-  version "13.6.0"
-  resolved "https://registry.yarnpkg.com/@0x/contract-wrappers/-/contract-wrappers-13.6.0.tgz#78255efaa3b7a3a83bf3e57e6236b8ff2a5b8f19"
-  integrity sha512-vS+su9qkQhmvsX59TmlTcpx4SODNa1bhBNoLmslSLIIKWOKTIw5ZAp6dR7mlw3mdKvg7L/caM2W5cdYgq3O7yw==
-  dependencies:
-    "@0x/assert" "^3.0.6"
-    "@0x/base-contract" "^6.2.0"
-    "@0x/contract-addresses" "^4.6.0"
-    "@0x/json-schemas" "^5.0.6"
-    "@0x/types" "^3.1.2"
-    "@0x/utils" "^5.4.0"
-    "@0x/web3-wrapper" "^7.0.6"
-    ethereum-types "^3.1.0"
-    ethers "~4.0.4"
-
 "@0x/contract-wrappers@^13.6.3":
   version "13.6.3"
   resolved "https://registry.yarnpkg.com/@0x/contract-wrappers/-/contract-wrappers-13.6.3.tgz#82333bc473615c871aaf1c222a20750b8d332eca"
@@ -193,12 +170,12 @@
     ethereum-types "^3.1.0"
     ethers "~4.0.4"
 
-"@0x/contracts-dev-utils@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@0x/contracts-dev-utils/-/contracts-dev-utils-1.1.1.tgz#7835501b7388cfbcd372cf25b4ea5a4b18aaa040"
-  integrity sha512-rmEX914SyLauZA0caRN/t9QEa/4gxzT55VNrQKWSO0IoPHff01OkrSimo6JwKK2U8oW0boVCGSOQycSfJS9pgg==
+"@0x/contracts-dev-utils@^1.3.3":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@0x/contracts-dev-utils/-/contracts-dev-utils-1.3.3.tgz#3bb8e34662d0e9432dbd1b0417c7c9f6a9668dd9"
+  integrity sha512-s+hqP7oFbvlek9BZMMcdzodvyWI/FZRZz6rTsiTEZGgo0RPcjFafuwQA31PopM4a/rx4MYN/jReCASubLxsCoA==
   dependencies:
-    "@0x/base-contract" "^6.2.0"
+    "@0x/base-contract" "^6.2.1"
 
 "@0x/json-schemas@^4.1.0-beta.2":
   version "4.1.0-beta.3"
@@ -268,31 +245,31 @@
     ethers "~4.0.4"
     lodash "^4.17.11"
 
-"@0x/order-utils@^10.2.1":
-  version "10.2.1"
-  resolved "https://registry.yarnpkg.com/@0x/order-utils/-/order-utils-10.2.1.tgz#73e59a9e63823fc5204b0145ac73372234eb0547"
-  integrity sha512-bkfUgqAb6ilk8zrzMsfKySRStDgbtbf1U+qUikXzf2EeZsQkAht5AkjxjH3EjK60O5VBf/61zTg86wdjYtH3gg==
+"@0x/order-utils@^10.2.4":
+  version "10.2.4"
+  resolved "https://registry.yarnpkg.com/@0x/order-utils/-/order-utils-10.2.4.tgz#23afe4656c9c71f2cf80f510154f7e2900515d68"
+  integrity sha512-ekxE/a1zaJEetlYEiBQawNpB4QInUXFAXdSi4uD4203oDvJzcUE4vnoCfyx/VMm3Fr94y6B3kIvXy6uMoC8+3w==
   dependencies:
-    "@0x/assert" "^3.0.6"
-    "@0x/contract-wrappers" "^13.6.0"
-    "@0x/json-schemas" "^5.0.6"
-    "@0x/utils" "^5.4.0"
-    "@0x/web3-wrapper" "^7.0.6"
+    "@0x/assert" "^3.0.7"
+    "@0x/contract-wrappers" "^13.6.3"
+    "@0x/json-schemas" "^5.0.7"
+    "@0x/utils" "^5.4.1"
+    "@0x/web3-wrapper" "^7.0.7"
     ethereumjs-util "^5.1.1"
     ethers "~4.0.4"
     lodash "^4.17.11"
 
-"@0x/orderbook@^2.2.1":
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/@0x/orderbook/-/orderbook-2.2.1.tgz#8f0e4f82dc79e4df2bf3e0d2b9d1dd3a011d0994"
-  integrity sha512-ghJdxxne1WFcZzae0ZkEm4rInb2+owTJmHUkFk2Rto3i23lMdGZX9mapGWsFMI8XVs67zUpV4Vx4J27pC/tATw==
+"@0x/orderbook@^2.2.5":
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/@0x/orderbook/-/orderbook-2.2.5.tgz#67f6e00f421f14d030248b09b17fea164498d8d4"
+  integrity sha512-b0d42uoJ6+DcX2rDvxIbtKfc6W77hryAqQZ3eA5rfRJ7vRXUq39C6AS7eiao2sDtyvZT9MVE5Gh2jdeDBidklQ==
   dependencies:
-    "@0x/assert" "^3.0.6"
-    "@0x/connect" "^6.0.6"
-    "@0x/contracts-dev-utils" "^1.1.1"
+    "@0x/assert" "^3.0.7"
+    "@0x/connect" "^6.0.7"
+    "@0x/contracts-dev-utils" "^1.3.3"
     "@0x/mesh-rpc-client" "^7.0.4-beta-0xv3"
-    "@0x/order-utils" "^10.2.1"
-    "@0x/utils" "^5.4.0"
+    "@0x/order-utils" "^10.2.4"
+    "@0x/utils" "^5.4.1"
 
 "@0x/subproviders@^6.0.8":
   version "6.0.8"
@@ -505,20 +482,6 @@
     "@0x/typescript-typings" "^5.0.1"
     "@0x/utils" "^5.2.0"
     ethereum-types "^3.0.0"
-    ethereumjs-util "^5.1.1"
-    ethers "~4.0.4"
-    lodash "^4.17.11"
-
-"@0x/web3-wrapper@^7.0.6":
-  version "7.0.6"
-  resolved "https://registry.yarnpkg.com/@0x/web3-wrapper/-/web3-wrapper-7.0.6.tgz#d0ccbc59839b5dc35fa5f94e1fdd6fb37b2d53ab"
-  integrity sha512-ErVNPzD4qjVCEigzg7SA7nSnKW1XnoF0krSbUNKqg2AXiLWU4J81bp+lqf08IzjcMdq4k+d7VYc9jYh88xRTRw==
-  dependencies:
-    "@0x/assert" "^3.0.6"
-    "@0x/json-schemas" "^5.0.6"
-    "@0x/typescript-typings" "^5.0.2"
-    "@0x/utils" "^5.4.0"
-    ethereum-types "^3.1.0"
     ethereumjs-util "^5.1.1"
     ethers "~4.0.4"
     lodash "^4.17.11"


### PR DESCRIPTION
Creates an easy UI for market makers to place limit orders on the orderbook. The interface takes into account all normal data that a market maker needs to place competitive prices on the orderbook.

With this interface is possible to place buy and limit orders, get the best bid and ask prices, adjust the buy and sell price, adjust order size ratio between bids and asks, adjust order expire time.

![image](https://user-images.githubusercontent.com/8621730/77242165-4ac9c080-6bda-11ea-8e6f-e2b5b83f45d0.png)

Additionally, the trader has access to some metrics like protocol and Eth fees collected, buy base and quote, and sell base and quote tokens to check the profitability of their trades.

![image](https://user-images.githubusercontent.com/8621730/77242202-b1e77500-6bda-11ea-821b-82512f1eabe1.png)
